### PR TITLE
Fix multiple invocations of $watch

### DIFF
--- a/apps/st2-actions/controller.js
+++ b/apps/st2-actions/controller.js
@@ -26,17 +26,19 @@ angular.module('main')
 
 angular.module('main')
 
-  .controller('st2ActionsCtrl', function ($scope, st2Api, $rootScope) {
+  .controller('st2ActionsCtrl', function ($scope, st2Api) {
 
-    st2Api.actions.$watch('list() | unwrap', function (list) {
+    $scope._api = st2Api;
+
+    $scope.$watch('_api.actions.list() | unwrap', function (list) {
       $scope.groups = list && _.groupBy(list, 'content_pack');
     });
 
-    $rootScope.$watch('state.params.page', function (page) {
+    $scope.$watch('$root.state.params.page', function (page) {
       st2Api.actions.fetch(page);
     });
 
-    $rootScope.$watch('state.params.id', function (id) {
+    $scope.$watch('$root.state.params.id', function (id) {
       // TODO: figure out why you can't use $filter('unwrap')(...) here
       st2Api.actions.get(id).then(function (action) {
         $scope.action = action;
@@ -78,7 +80,7 @@ angular.module('main')
     $scope.actionHasFile = function (action) {
       var runnersWithFiles = ['workflow', 'run-local-script', 'action-chain'];
 
-      return _.contains(runnersWithFiles, action.runner_type);
+      return action && _.contains(runnersWithFiles, action.runner_type);
     };
 
   })

--- a/apps/st2-history/controller.js
+++ b/apps/st2-history/controller.js
@@ -27,9 +27,11 @@ angular.module('main')
 angular.module('main')
 
   // List history records
-  .controller('st2HistoryCtrl', function ($scope, st2Api, $rootScope) {
+  .controller('st2HistoryCtrl', function ($scope, st2Api) {
 
-    st2Api.history.$watch('list() | unwrap', function (list) {
+    $scope._api = st2Api;
+
+    $scope.$watch('_api.history.list() | unwrap', function (list) {
       // Group all the records by periods of 24 hour
       var period = 24 * 60 * 60 * 1000;
 
@@ -45,18 +47,18 @@ angular.module('main')
       }).value();
     });
 
-    $rootScope.$watch('state.params.page', function (page) {
+    $scope.$watch('$root.state.params.page', function (page) {
       st2Api.history.fetch(page, {
         parent: 'null'
       });
     });
 
-    $rootScope.$watch('state.params.id', function (id) {
+    $scope.$watch('$root.state.params.id', function (id) {
       // TODO: figure out why you can't use $filter('unwrap')(...) here
       st2Api.history.get(id).then(function (record) {
         $scope.record = record;
 
-        // Spec and payload to bould a form for the action input. Strict resemblence to form from
+        // Spec and payload to build a form for the action input. Strict resemblence to form from
         // Action tab is not guaranteed.
         $scope.spec = _({}).defaults(record.action.parameters, record.runner.runner_parameters)
           .mapValues(function (e) {

--- a/apps/st2-rules/controller.js
+++ b/apps/st2-rules/controller.js
@@ -28,16 +28,19 @@ angular.module('main')
 angular.module('main')
 
   // List rules
-  .controller('st2RulesCtrl', function ($scope, st2Api, $rootScope) {
-    st2Api.rules.$watch('list() | unwrap', function (list) {
+  .controller('st2RulesCtrl', function ($scope, st2Api) {
+
+    $scope._api = st2Api;
+
+    $scope.$watch('_.api.rules.list() | unwrap', function (list) {
       $scope.rules = list;
     });
 
-    $rootScope.$watch('state.params.page', function (page) {
+    $scope.$watch('$root.state.params.page', function (page) {
       st2Api.rules.fetch(page);
     });
 
-    $rootScope.$watch('state.params.id', function (id) {
+    $scope.$watch('$root.state.params.id', function (id) {
       // TODO: figure out why you can't use $filter('unwrap')(...) here
       st2Api.rules.get(id).then(function (rule) {
         $scope.rule = rule;


### PR DESCRIPTION
Apparently, when you $watch on a $rootScope, this watches didn't get cleared when you switch your application and tend to pile up indefinitely creating a very nasty leak resulting in a flood of requests to the backend. On the other hand, local $scope, while providing an access to the same root scope variable, gets destructed and clears it's watches on an application switch.

Same with st2Api scopes. Apparently, 'list()' watches also have a tendency to pile up and cause a wide variety of problems down the road. I intentionaly left $scope._api in a local scope as I'm not sure what exactly am I going to do with the knowledge I've just acquired and it's a bit too soon to try and optimize this things.
