### PR TITLE
Fix: Action section in rule should use ref field.

### DIFF
--- a/apps/st2-rules/controller.js
+++ b/apps/st2-rules/controller.js
@@ -63,7 +63,7 @@ angular.module('main')
             }
           });
 
-          st2Api.actions.find({ref: rule.action.action}).then(function (actions) {
+          st2Api.actions.find({ref: rule.action.ref}).then(function (actions) {
             if (!_.isEmpty(actions)) {
               var schema = actions[0].parameters;
               $scope.actionSchema = disable(schema);


### PR DESCRIPTION
gulp test is failing with a weird error about docs. Fails on master as well.

```
~/s/s/st2web git:master ❯❯❯ gulp test                                                                                                                                                                                             ⏎ ✱
[14:20:41] Using gulpfile ~/src/storm/st2web/gulpfile.js
[14:20:41] Starting 'gulphint'...
[14:20:41] Starting 'scripts'...
[14:20:41] Starting 'font'...
[14:20:41] Finished 'gulphint' after 74 ms
[14:20:41] Finished 'scripts' after 421 ms
[14:20:41] Finished 'font' after 583 ms
[14:20:41] Starting 'styles'...
[14:20:42] Finished 'styles' after 552 ms
[14:20:42] Starting 'build'...
[14:20:42] Finished 'build' after 6.75 μs
[14:20:42] Starting 'serve'...
[14:20:42] Server started on 3000 port
[14:20:42] Finished 'serve' after 2.92 ms
[14:20:42] Starting 'test'...
Using the selenium server at http://localhost:4444/wd/hub
F

Failures:

  1) Stanley docs should have a section about the rules we have in our system
   Message:
     NoSuchElementError: No element found using locator: By.cssSelector(".st2-docs__rules")
   Stacktrace:
     NoSuchElementError: No element found using locator: By.cssSelector(".st2-docs__rules")
==== async task ====
Asynchronous test function: it()
Error
    at [object Object].<anonymous> (/Users/lakshmi/src/storm/st2web/tests/test-docs.js:8:3)
    at Object.<anonymous> (/Users/lakshmi/src/storm/st2web/tests/test-docs.js:5:1)

Finished in 2.846 seconds
1 test, 1 assertion, 1 failure

[14:20:45] E2E test failed: protractor exited with code 1
[14:20:45] 'test' errored after 3.62 s
[14:20:45] Error in plugin 'gulp-protractor'
protractor exited with code 1
~/s/s/st2web git:master ❯❯
```
