### PR TITLE
Make UI only show the parts that are loaded

### DIFF
--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -8,7 +8,8 @@
           Actions
         </div>
 
-        <div class="st2-panel__toolbar-search">
+        <div class="st2-panel__toolbar-search"
+            ng-show="groups">
           <form>
             <input type="search"
               class="st2-panel__search-bar"
@@ -70,7 +71,8 @@
     <div class="st2-loader"></div>
   </div>
 
-  <div class="st2-panel__details st2-details">
+  <div class="st2-panel__details st2-details"
+      ng-show="action">
     <div class="st2-details__tabs">
       <div class="st2-details__tab-label"
           ng-class="{'st2-details__tab-label--active': $root.isState(['^.general', '^.list'])}"

--- a/apps/st2-history/controller.js
+++ b/apps/st2-history/controller.js
@@ -44,7 +44,7 @@ angular.module('main')
       pHistoryList = st2api.history.list(_.assign({
         parent: 'null',
         page: $rootScope.page
-      }, $scope.$root.filters));
+      }, $scope.$root.active_filters));
 
       pHistoryList.then(function (list) {
         // Group all the records by periods of 24 hour
@@ -73,7 +73,7 @@ angular.module('main')
       });
     };
 
-    $scope.$watch('[$root.filters, $root.page]', listUpdate, true);
+    $scope.$watch('[$root.active_filters, $root.page]', listUpdate, true);
 
     $scope.$watch('$root.state.params.id', function (id) {
       if (!pHistoryList) {

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -9,10 +9,14 @@
           History
         </div>
 
-        <div class="st2-panel__toolbar-filters">
-          <div class="st2-filter" filters="filters" type="action"></div>
-          <div class="st2-filter" filters="filters" type="trigger_type" label="Trigger Type"></div>
-          <div class="st2-filter" filters="filters" type="rule"></div>
+        <div class="st2-panel__toolbar-filters"
+            ng-show="filters">
+          <div class="st2-filter" filters="filters" type="action"
+            ng-hide="_.isEmpty(filters['action'])"></div>
+          <div class="st2-filter" filters="filters" type="trigger_type" label="Trigger Type"
+            ng-hide="_.isEmpty(filters['trigger_type'])"></div>
+          <div class="st2-filter" filters="filters" type="rule"
+            ng-hide="_.isEmpty(filters['rule'])"></div>
         </div>
       </div>
 
@@ -99,7 +103,8 @@
     <div class="st2-loader"></div>
   </div>
 
-  <div class="st2-panel__details st2-details">
+  <div class="st2-panel__details st2-details"
+      ng-show="record">
     <div class="st2-panel__scroller">
 
       <div class="st2-details__panel">

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -8,7 +8,8 @@
           Rules
         </div>
 
-        <div class="st2-panel__toolbar-search">
+        <div class="st2-panel__toolbar-search"
+            ng-show="rules">
           <form>
             <input type="search"
               class="st2-panel__search-bar"
@@ -70,7 +71,8 @@
     <div class="st2-loader"></div>
   </div>
 
-  <div class="st2-panel__details st2-details">
+  <div class="st2-panel__details st2-details"
+      ng-show="rule">
 
     <div class="st2-details__tabs">
       <div class="st2-details__tab-label"

--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ angular.module('main')
     var filters = ['action', 'trigger_type', 'rule'];
 
     $rootScope.$watchCollection('state.params', function (params) {
-      $rootScope.filters = _.pick(params, filters);
+      $rootScope.active_filters = _.pick(params, filters);
     });
 
     // References

--- a/modules/st2-filter/template.html
+++ b/modules/st2-filter/template.html
@@ -1,12 +1,12 @@
 <div class="st2-filter__label"
-  ng-class="{'st2-filter__label--active': $root.filters[type]}"
+  ng-class="{'st2-filter__label--active': $root.active_filters[type]}"
   ng-click="toggle()">
   {{ (label || type) | capitalize }}
 </div>
 <div class="st2-filter__variants">
   <div class="st2-filter__list">
     <div class="st2-filter__item"
-        ng-class="{'st2-filter__item--active': name == $root.filters[type]}"
+        ng-class="{'st2-filter__item--active': name == $root.active_filters[type]}"
         ng-repeat="name in filters[type] track by $index"
         ng-click="pick(name)">
       {{ name }}


### PR DESCRIPTION
Not only this helps us avoid having half-empty panels during data loading on a slow connection, it also gracefully handles the case when the action refered in the url doesn't exist.
