### PR TITLE
Add nice note for Early Access friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 StackStorm Web UI
 =================
 
+Early Access Users
+------------------
+Thank you for trying out our software! Be ye warned, this project is under
+active and rapid development. As such, there may be times where things may
+quite work as expected. Be sure to let us know by submitting bugs to:
+https://github.com/StackStorm/st2web/issues. We'd also love to know what you
+enjoy using, so don't be shy!
+
+The current 'stable' version is `v0.6.0`. This is a `git` branch you can
+checkout with the following command: `git checkout v0.6.0`.
+
+During the early access period, we will keep the most 'stable' version updated
+in the master branch of this project.
+
+
 Quick start
 -----------
 


### PR DESCRIPTION
While deploying this project today, I noticed there were some issues with selecting actions. This is currently being ironed out. @DoriftoShoes mentions that there is a working commit that he is using internally, so I thought it would be good to make sure all of our @StackStorm/earlyaccess friends know how best to use the interface while they give feedback or tell us how awesome everything is. :wink:.

This PR accompanies a `git` tag: https://github.com/StackStorm/st2web/tree/v0.6.0. If we end up needing to overwrite this tag in the future as we unify the build pipelines, that's fine. It's a fine stake in the ground for today, and lets everyone know it has compatibility with the current released version.