### PR TITLE
Fix Actions responsiveness

### DIFF
--- a/apps/st2-actions/controller.js
+++ b/apps/st2-actions/controller.js
@@ -35,7 +35,7 @@ angular.module('main')
     st2LoaderService.reset();
     st2LoaderService.start();
 
-    var pActionList = st2api.client.actionOverview.list().then(function (result) {
+    var pActionList = st2api.client.actions.list().then(function (result) {
       st2LoaderService.stop();
       return result;
     }).catch(function (err) {
@@ -72,7 +72,7 @@ angular.module('main')
 
     $scope.$watch('$root.state.params.ref', function (ref) {
       var promise = ref ? st2api.client.actionOverview.get(ref) : pActionList.then(function (actions) {
-        return _.first(actions);
+        return st2api.client.actionOverview.get(_.first(actions).ref);
       });
 
       promise.then(function (action) {


### PR DESCRIPTION
Helps optimize page loading time by only loading the data we need here and now.

This would save us around 1.5sec per 300 actions, but that's not our main bottleneck.