### PR TITLE
Reduce the size of production assets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,9 +18,9 @@
     "moment": "~2.8.0",
     "angular-moment": "~0.8.0",
     "angular-sanitize": "~1.3.4",
-    "highlightjs-v8.1": "~8.2.0",
     "uri.js": "~1.14.2",
-    "angular-busy": "~4.1.2"
+    "angular-busy": "~4.1.2",
+    "prism": "*"
   },
   "overrides": {
     "uri.js": {
@@ -31,6 +31,12 @@
     },
     "angular-animate": {
       "ignore": true
+    },
+    "prism": {
+      "main": [
+        "prism.js",
+        "components/prism-python.js"
+      ]
     }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "normalize-css": "~3.0.1",
     "moment": "~2.8.0",
     "angular-moment": "~0.8.0",
-    "angular-mocks": "~1.3.4",
     "angular-sanitize": "~1.3.4",
     "highlightjs-v8.1": "~8.2.0",
     "uri.js": "~1.14.2",
@@ -29,6 +28,9 @@
     },
     "jquery": {
       "main": []
+    },
+    "angular-animate": {
+      "ignore": true
     }
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var gulp = require('gulp')
   , templateCache = require('gulp-angular-templatecache')
   , ngAnnotate = require('gulp-ng-annotate')
   , uglify = require('gulp-uglify')
+  , size = require('gulp-size')
   ;
 
 var express = require('express')
@@ -166,26 +167,54 @@ gulp.task('production-template', function () {
     .pipe(templateCache({
       module: 'main'
     }))
-    .pipe(gulp.dest('build/js'));
+    .pipe(gulp.dest('build/js'))
+    .pipe(size({
+      showFiles: true
+    }))
+    .pipe(size({
+      showFiles: true,
+      gzip: true
+    }));
 });
 
 gulp.task('production-styles', ['styles'], function () {
   return gulp.src('./css/*.css')
-    .pipe(gulp.dest('build/css/'));
+    .pipe(gulp.dest('build/css/'))
+    .pipe(size({
+      showFiles: true
+    }))
+    .pipe(size({
+      showFiles: true,
+      gzip: true
+    }));
 });
 
 gulp.task('production-components', function () {
   return gulp.src(components)
     .pipe(concat('components.js'))
     .pipe(uglify())
-    .pipe(gulp.dest('build/js'));
+    .pipe(gulp.dest('build/js'))
+    .pipe(size({
+      showFiles: true
+    }))
+    .pipe(size({
+      showFiles: true,
+      gzip: true
+    }));
 });
 
 gulp.task('production-modules', function () {
   return gulp.src(modules)
     .pipe(ngAnnotate())
     .pipe(concat('modules.js'))
-    .pipe(gulp.dest('build/js'));
+    .pipe(gulp.dest('build/js'))
+    .pipe(size({
+      showFiles: true
+    }))
+    .pipe(size({
+      showFiles: true,
+      gzip: true
+    }));
 });
 
 gulp.task('production-html', function () {

--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@
   <script src="components/moment/moment.js"></script>
   <script src="components/angular-moment/angular-moment.js"></script>
   <script src="components/angular-sanitize/angular-sanitize.js"></script>
-  <script src="components/highlightjs-v8.1/highlight.pack.js"></script>
+  <script src="components/prism/prism.js"></script>
+  <script src="components/prism/components/prism-python.js"></script>
   <script src="components/uri.js/src/URI.js"></script>
   <script src="components/angular-busy/dist/angular-busy.js"></script>
   <!-- endbuild -->

--- a/index.html
+++ b/index.html
@@ -17,10 +17,8 @@
   <script src="components/angular-ui-router/release/angular-ui-router.js"></script>
   <script src="components/moment/moment.js"></script>
   <script src="components/angular-moment/angular-moment.js"></script>
-  <script src="components/angular-mocks/angular-mocks.js"></script>
   <script src="components/angular-sanitize/angular-sanitize.js"></script>
   <script src="components/highlightjs-v8.1/highlight.pack.js"></script>
-  <script src="components/angular-animate/angular-animate.js"></script>
   <script src="components/uri.js/src/URI.js"></script>
   <script src="components/angular-busy/dist/angular-busy.js"></script>
   <!-- endbuild -->

--- a/less/style.less
+++ b/less/style.less
@@ -1,5 +1,5 @@
 @import (inline) '../components/normalize-css/normalize.css';
-@import (inline) '../components/highlightjs-v8.1/styles/monokai.css';
+@import (inline) '../components/prism/themes/prism-okaidia.css';
 @import (inline) '../components/angular-busy/dist/angular-busy.css';
 
 @import 'fonts';

--- a/modules/st2-highlight/directive.js
+++ b/modules/st2-highlight/directive.js
@@ -1,13 +1,8 @@
-/*global hljs:true*/
+/*global Prism:true*/
 'use strict';
 
 angular.module('main')
-  .config(function () {
-    hljs.configure({
-      languages: ['json']
-    });
-  })
-  .directive('st2Highlight', function ($filter) {
+  .directive('st2Highlight', function () {
 
     function getType(string) {
       try {
@@ -35,7 +30,7 @@ angular.module('main')
 
         scope.string = {
           json: function () {
-            return hljs.highlight('json', $filter('json')(JSON.parse(code))).value;
+            return Prism.highlight(code, Prism.languages['javascript']);
           },
           string: function () {
             return code && code.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
@@ -43,7 +38,7 @@ angular.module('main')
             });
           },
           object: function () {
-            return code && hljs.highlight('json', $filter('json')(code)).value;
+            return code && Prism.highlight(code, Prism.languages['javascript']);
           }
         }[scope.type](code);
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gulp-ng-annotate": "^0.5.2",
     "gulp-plumber": "^0.6.5",
     "gulp-protractor": "0.0.11",
+    "gulp-size": "^1.2.1",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.1",
     "lodash": "^2.4.1",


### PR DESCRIPTION
By removing some unnecessary packages and replacing poorly packed hljs with Lea Verou's Prism, we've managed to reduce the size of `components.js` in half.

There is still an opportunity to improve on that result by using pre-uglified versions of packages (mainly, angular and lodash), but that's a minor improvement (estimated around 5-7%).