### PR TITLE
Remember the groups collapsed

### DIFF
--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -25,9 +25,10 @@
 
         <div class="st2-flex-table"
             ng-repeat="(name, list) in groups"
+            ng-class="{'st2-flex-table--contracted': $root.tabs.isClosed('action', name)}"
             ng-if="groups && !_.isEmpty(groups)">
           <div class="st2-flex-table__caption st2-flex-table__caption--pack"
-              ng-click="toggle()">
+              ng-click="$root.tabs.toggle('action', name)">
             <h2 class="st2-flex-table__caption-title">{{ name }}</h2>
           </div>
 

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -31,10 +31,11 @@
       <div class="st2-panel__content">
         <div class="st2-flex-table"
             ng-repeat="group in groups = (history | orderBy:'period':true)"
+            ng-class="{'st2-flex-table--contracted': $root.tabs.isClosed('history', group.period)}"
             ng-if="history && !_.isEmpty(groups)">
 
           <div class="st2-flex-table__caption st2-flex-table__caption--date"
-              ng-click="toggle()">
+              ng-click="$root.tabs.toggle('history', group.period)">
             <h2 class="st2-flex-table__caption-title">{{ group.period | date:'fullDate':'UTC'}}</h2>
           </div>
 

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -31,9 +31,10 @@
       <div class="st2-panel__content">
 
         <div class="st2-flex-table"
+            ng-class="{'st2-flex-table--contracted': $root.tabs.isClosed('rules', 'general')}"
             ng-if="rules && !_.isEmpty(rules)">
           <div class="st2-flex-table__caption"
-              ng-click="toggle()">
+              ng-click="$root.tabs.toggle('rules', 'general')">
             <h2 class="st2-flex-table__caption-title">General</h2>
           </div>
 

--- a/main.js
+++ b/main.js
@@ -74,6 +74,29 @@ angular.module('main')
     // $scope.$on('$stateChangeStart', function (event, toState) {
     //   window.name = toState.name;
     // });
+
+    $rootScope.tabs = (function () {
+      var closed = {
+        action: [],
+        history: [],
+        rules: []
+      };
+
+      return {
+        toggle: function (type, name) {
+          var index = closed[type].indexOf(name);
+
+          if (index > -1) {
+            closed[type].splice(index, 1);
+          } else {
+            closed[type].push(name);
+          }
+        },
+        isClosed: function (type, name) {
+          return closed[type].indexOf(name) !== -1;
+        }
+      };
+    })();
   });
 
 angular.module('main')

--- a/modules/st2-flex-table/directive.js
+++ b/modules/st2-flex-table/directive.js
@@ -6,12 +6,7 @@ angular.module('main')
     return {
       restrict: 'C',
       transclude: true,
-      template: '<div ng-transclude></div>',
-      link: function postLink(scope, element) {
-        scope.toggle = function () {
-          element.toggleClass('st2-flex-table--contracted');
-        };
-      }
+      template: '<div ng-transclude></div>'
     };
 
   });


### PR DESCRIPTION
Reported by @manasdk.

Now any group collapsed by clicking the header stay collapsed during the whole session. The setting doesn't persist through tab reload.