### PR TITLE
Removing a limit on the execution workflow list

### DIFF
--- a/apps/st2-actions/controller.js
+++ b/apps/st2-actions/controller.js
@@ -219,7 +219,8 @@ angular.module('main')
       if ($filter('isExpandable')(record) && record._expanded) {
         st2api.client.executions.list({
           parent: record.id,
-          exclude_attributes: 'result,trigger_instance'
+          exclude_attributes: 'result,trigger_instance',
+          limit: 0
         }).then(function (records) {
           if (!record._children) {
             record._children = records;

--- a/apps/st2-actions/controller.js
+++ b/apps/st2-actions/controller.js
@@ -90,6 +90,7 @@ angular.module('main')
         st2api.client.executions.list({
           'action': $scope.$root.getRef(action),
           'limit': 5,
+          'exclude_attributes': 'result,trigger_instance',
           'parent': 'null'
         }).then(function (history) {
           $scope.inProgress = false;


### PR DESCRIPTION
Fixes #180 — an execution now shows a full workflow when expanded from a list.