### PR TITLE
Freeze gulp-html-replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-autoprefixer": "0.0.7",
     "gulp-concat": "^2.2.0",
     "gulp-csscomb": "3.0.4",
-    "gulp-html-replace": "^1.4.1",
+    "gulp-html-replace": "~1.4.1",
     "gulp-jshint": "^1.5.5",
     "gulp-less": "^3.0.2",
     "gulp-ng-annotate": "^0.5.2",


### PR DESCRIPTION
Version 1.5.0 includes new parser which inconsistently ignores linebreaks and indentation.