### PR TITLE
"Namespace" module for trigger validation

### DIFF
--- a/modules/st2-auto-form/modules/st2-form-namespace/directive.js
+++ b/modules/st2-auto-form/modules/st2-form-namespace/directive.js
@@ -1,0 +1,129 @@
+'use strict';
+angular.module('main')
+  .directive('st2FormNamespace', function ($timeout) {
+    return {
+      restrict: 'C',
+      require: 'ngModel',
+      scope: {
+        'spec': '=',
+        'options': '=',
+        'ngModel': '=',
+        'disabled': '='
+      },
+      templateUrl: 'modules/st2-auto-form/modules/st2-form-namespace/template.html',
+      link: function (scope, element, attrs, ctrl) {
+        scope.name = ctrl.$name;
+
+        var selected = 0;
+        Object.defineProperty(scope, 'selected', {
+          get: function () {
+            if (!scope.sample) {
+              return 0;
+            } else {
+              return selected < scope.sample.length ? selected : scope.sample.length - 1;
+            }
+          },
+          set: function (index) {
+            selected = index;
+          }
+        });
+
+        scope.choose = function (index) {
+          if (_.isUndefined(index)) {
+            index = scope.selected;
+          } else {
+            scope.selected = index;
+          }
+
+          scope.rawResult = scope.sample[index].name;
+        };
+
+        var timerPromise
+          , timeout = 200; // may not be enough
+        scope.toggleSuggestions = function (to) {
+          $timeout.cancel(timerPromise);
+          timerPromise = $timeout(function () {
+            scope.showSuggestions = to;
+          }, timeout);
+          return timerPromise;
+        };
+
+        scope.focus = function () {
+          return scope.toggleSuggestions(true);
+        };
+
+        scope.blur = function () {
+          return scope.toggleSuggestions(false).then(function () {
+            ctrl.$setViewValue(scope.rawResult);
+          });
+        };
+
+        ctrl.$render = function () {
+          scope.rawResult = ctrl.$viewValue;
+        };
+
+        scope.keydown = function ($event) {
+          scope.focus();
+
+          if ($event.keyCode === 38) {
+            $event.preventDefault();
+            scope.selected = scope.selected - 1;
+          }
+
+          if ($event.keyCode === 40) {
+            $event.preventDefault();
+            scope.selected = scope.selected + 1;
+          }
+
+          if ($event.keyCode === 13) {
+            $event.preventDefault();
+            scope.choose();
+            scope.blur();
+          }
+        };
+
+      }
+    };
+
+  })
+
+  .directive('ngNamespaces', function namespaceDirective() {
+    return {
+      require: '?ngModel',
+      restrict: 'A',
+      link: function(scope, elm, attrs, ctrl) {
+        if (!ctrl) {
+          return;
+        }
+
+        var namespaces;
+
+        scope.$watch(attrs['ngNamespaces'], function (attribute) {
+          namespaces = attribute;
+        });
+
+        scope.$watch('ngNamespaces', function () {
+          ctrl.$validate();
+        });
+
+        ctrl.$validators.namespaces = function (value) {
+
+          if (_.isEmpty(value) || _.isUndefined(namespaces)) {
+            return true;
+          } else {
+            return _.map(namespaces, function(namespace) {
+              var name = namespace.name;
+              console.log(name);
+              var escaped = name.replace(/\./g, '\.');
+              return value === name ||
+                     new RegExp('^'+escaped+'(\.[a-z0-9]+)*$').test(value);
+            }).reduce(function(a, b) {
+              return a || b;
+            });
+          }
+        };
+      }
+    };
+  })
+
+  ;

--- a/modules/st2-auto-form/modules/st2-form-namespace/template.html
+++ b/modules/st2-auto-form/modules/st2-form-namespace/template.html
@@ -1,0 +1,39 @@
+<label class="st2-auto-form__label"
+  ng-class="{'st2-auto-form--required': spec.required}">
+
+  <div class="st2-auto-form__title"
+      ng-if="spec.name || name">
+    {{ spec.name || name }}
+  </div>
+
+  <input type="text"
+    class="st2-auto-form__field st2-auto-form__field--combo"
+    placeholder="{{spec.default}}"
+    ng-required="spec.required"
+    ng-model="rawResult"
+    ng-model-options="{
+      allowInvalid: true
+    }"
+    ng-focus="focus()"
+    ng-blur="blur()"
+    ng-namespaces="spec.namespaces"
+    ng-keydown="keydown($event)"
+    ng-disabled="disabled" />
+
+</label>
+
+<div class="st2-auto-form__suggestions"
+    ng-show="showSuggestions && sample.length">
+  <div class="st2-auto-form__suggestion"
+      ng-repeat="suggestion in sample = (spec.namespaces | filter:{name:rawResult})"
+      ng-class="{'st2-auto-form__suggestion--active': $parent.selected == $index}"
+      ng-click="choose($index)">
+    <div class="st2-details__header-name">{{ suggestion.name }}</div>
+    <div class="st2-details__header-description">{{ suggestion.description }}</div>
+  </div>
+</div>
+
+<p class="st2-auto-form__description"
+    ng-if="spec.description">
+  {{ spec.description }}
+</p>

--- a/modules/st2-criteria/directive.js
+++ b/modules/st2-criteria/directive.js
@@ -54,7 +54,7 @@ angular.module('main')
           };
 
           if (trigger && trigger.payload_schema && trigger.payload_schema.properties) {
-            scope.autocompleteSpec.enum =
+            scope.autocompleteSpec.namespaces =
               _.map(trigger.payload_schema.properties, function (spec, name) {
                 return {
                   name: 'trigger.' + name,

--- a/modules/st2-criteria/template.html
+++ b/modules/st2-criteria/template.html
@@ -1,7 +1,7 @@
 <div>
   <div class="st2-criteria__line"
       ng-repeat="item in result">
-    <div class="st2-form-combobox st2-criteria__entity"
+    <div class="st2-form-namespace st2-criteria__entity"
         spec="autocompleteSpec"
         disabled="disabled"
         ng-model="item.key">


### PR DESCRIPTION
To tackle issue #183 I’ve added `st2-form-namespace` module which works similar to `st2-form-combobox`, accepts a list of suggestions and shows an autocomplete popup.

The key difference is that `combobox` only accepts exact match (for `trigger.channel` it will only accept `trigger.channel` in the field), while `namespace` will also accept everything within the object (like `trigger.channel.name`).

I feel like this approach is safer than just removing validation: we’ll retain the original schema while also allowing flexibility inside it.

cc @enykeev 