### PR TITLE
Scroll to top after switching pages

### DIFF
--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -3,7 +3,7 @@
 <main class="st2-panel">
 
   <div class="st2-panel__view st2-actions" cg-busy="busy">
-    <div class="st2-panel__scroller">
+    <div class="st2-panel__scroller" id="st2-panel__scroller">
 
       <div class="st2-panel__toolbar">
         <div class="st2-panel__toolbar-title">

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -4,7 +4,7 @@
 
   <div class="st2-panel__view st2-history" cg-busy="busy">
 
-    <div class="st2-panel__scroller">
+    <div class="st2-panel__scroller" id="st2-panel__scroller">
 
       <div class="st2-panel__toolbar">
         <div class="st2-panel__toolbar-title">

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -3,7 +3,7 @@
 <main class="st2-panel">
 
   <div class="st2-panel__view st2-rules" cg-busy="busy">
-    <div class="st2-panel__scroller">
+    <div class="st2-panel__scroller" id="st2-panel__scroller">
 
       <div class="st2-panel__toolbar">
         <div class="st2-panel__toolbar-title">

--- a/main.js
+++ b/main.js
@@ -28,6 +28,11 @@ angular.module('main')
 
 angular.module('main')
   .controller('MainCtrl', function ($rootScope, $state) {
+
+    var scrollToTop = function() {
+      document.getElementById('st2-panel__scroller').scrollTop = 0;
+    };
+
     $rootScope.state = $state;
     $rootScope._ = _;
 
@@ -52,10 +57,10 @@ angular.module('main')
       $rootScope.maxPage = Math.ceil($rootScope.total_count / $rootScope.limit);
     });
     $rootScope.prevPage = function () {
-      $rootScope.state.go('.', { page: $rootScope.page - 1 });
+      $rootScope.state.go('.', { page: $rootScope.page - 1 }).then(scrollToTop);
     };
     $rootScope.nextPage = function () {
-      $rootScope.state.go('.', { page: ($rootScope.page || 1) + 1 });
+      $rootScope.state.go('.', { page: ($rootScope.page || 1) + 1 }).then(scrollToTop);
     };
 
     // Filtering

--- a/main.js
+++ b/main.js
@@ -29,6 +29,7 @@ angular.module('main')
 angular.module('main')
   .controller('MainCtrl', function ($rootScope, $state) {
 
+    // TODO: use a transclude or bind on $stateChangeSuccess instead.
     var scrollToTop = function() {
       document.getElementById('st2-panel__scroller').scrollTop = 0;
     };


### PR DESCRIPTION
@manasdk: 
> 3) Hitting `next` on a list page loads new data fine but I remain at the bottom of the page. This is actually annoying as it requires me to to scroll to top of the page anyway - could we scroll to the top automatically?

Note: I don’t really like putting this in the main controller, so if someone (cc @enykeev) can point me to another place where it would be more appropriate, I’ll gladly change that.