### PR TITLE
Changing "enums" to "suggestions" and disabling validation in st2-form-combobox

### DIFF
--- a/modules/st2-auto-form/modules/st2-form-combobox/directive.js
+++ b/modules/st2-auto-form/modules/st2-form-combobox/directive.js
@@ -87,7 +87,7 @@ angular.module('main')
 
   })
 
-  .directive('ngEnums', function enumDirective() {
+  .directive('ngSuggestions', function enumDirective() {
     return {
       require: '?ngModel',
       restrict: 'A',
@@ -96,19 +96,12 @@ angular.module('main')
           return;
         }
 
-        var enums;
+        var suggestions;
 
-        scope.$watch(attrs['ngEnums'], function (attribute) {
-          enums = attribute;
+        scope.$watch(attrs['ngSuggestions'], function (attribute) {
+          suggestions = attribute;
         });
 
-        scope.$watch('ngEnums', function () {
-          ctrl.$validate();
-        });
-
-        ctrl.$validators.enums = function (value) {
-          return _.isEmpty(value) || _.isUndefined(enums) || _.some(enums, {name: value});
-        };
       }
     };
   })

--- a/modules/st2-auto-form/modules/st2-form-combobox/template.html
+++ b/modules/st2-auto-form/modules/st2-form-combobox/template.html
@@ -16,7 +16,7 @@
     }"
     ng-focus="focus()"
     ng-blur="blur()"
-    ng-enums="spec.enum"
+    ng-suggestions="spec.enum"
     ng-keydown="keydown($event)"
     ng-disabled="disabled" />
 

--- a/modules/st2-remote-form/template.html
+++ b/modules/st2-remote-form/template.html
@@ -1,7 +1,7 @@
 <div class="st2-manual-form st2-form-combobox"
   name="{{name}}"
   spec="suggestionSpec"
-  ng-enums="suggestionSpec.enum"
+  ng-suggestions="suggestionSpec.enum"
   disabled="disabled"
   ng-model="ngModel[IDENT]">
 </div>


### PR DESCRIPTION
Another take on issue #183. Since we don’t use a strict schema, we don’t want to impose validation but should still have suggestions and autocomplete.

cc @enykeev 