### PR TITLE
Links to actions in Rules

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,21 +2,13 @@
 angular.module('main')
   .constant('st2Config', {
 
-    hosts: [
-      {
-        name: '001',
-        url: 'http://st2build001:9101'
-      }, 
-      {
-        name: 'Staging',
-        url: 'http://st2stage201:9101',
-        auth: 'http://st2stage201:9100',
-        flow: 'http://127.0.0.1:4000'
-      },
-      {
-        name: 'Express',
-        url: 'http://172.168.50.11:9101',
-        flow: 'http://127.0.0.1:4000'
-      }
-    ]
+    hosts: [{
+      name: 'Dev Env',
+      url: '//172.168.50.50:9101'
+    }, {
+      name: 'Express',
+      url: '//172.168.90.50:9101',
+      auth: true
+    }]
+
   });

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
   <script src="modules/st2-auto-form/modules/st2-form-input/directive.js"></script>
   <script src="modules/st2-auto-form/modules/st2-form-select/directive.js"></script>
   <script src="modules/st2-auto-form/modules/st2-form-text-field/directive.js"></script>
+  <script src="modules/st2-auto-form/modules/st2-form-text/directive.js"></script>
   <script src="modules/st2-criteria/directive.js"></script>
   <script src="modules/st2-filter/directive.js"></script>
   <script src="modules/st2-flex-table/directive.js"></script>

--- a/modules/st2-auto-form/modules/st2-form-text/directive.js
+++ b/modules/st2-auto-form/modules/st2-form-text/directive.js
@@ -1,0 +1,53 @@
+'use strict';
+angular.module('main')
+  .directive('st2FormText', function () {
+    var showLabel = function() {
+      // We may need to be able to hide labels some time in the future.
+      return true;
+    };
+    var generateLink = function(name) {
+      switch (name) {
+        case 'action':
+          return 'actions.general({ref: rawResult})';
+        default:
+          return false;
+      }
+    };
+    return {
+      restrict: 'C',
+      require: 'ngModel',
+      scope: {
+        'spec': '=',
+        'options': '=',
+        'ngModel': '=',
+        'disabled': '='
+      },
+      templateUrl: 'modules/st2-auto-form/modules/st2-form-text/template.html',
+      link: function (scope, element, attrs, ctrl) {
+        scope.name = ctrl.$name;
+        scope.showLabel = showLabel(scope.name);
+
+        ctrl.$render = function () {
+          scope.rawResult = ctrl.$viewValue;
+          scope.link = generateLink(scope.name, scope.rawResult);
+        };
+
+        scope.$watch('rawResult', function (rawResult) {
+          ctrl.$setViewValue({
+            number: function () {
+              return _.isUndefined(rawResult) ? rawResult : parseFloat(rawResult);
+            },
+            integer: function () {
+              return _.isUndefined(rawResult) ? rawResult : parseInt(rawResult);
+            },
+            string: function () {
+              return rawResult;
+            }
+          }[scope.spec && scope.spec.type || 'string']());
+        });
+      }
+    };
+
+  })
+
+  ;

--- a/modules/st2-auto-form/modules/st2-form-text/template.html
+++ b/modules/st2-auto-form/modules/st2-form-text/template.html
@@ -1,0 +1,16 @@
+<div class="st2-auto-form__title"
+    ng-if="showLabel">
+  {{ name }}
+</div>
+
+<div class="st2-auto-form__value">
+  <div class="st2-auto-form__text"
+      ng-if="!link">
+    {{ rawResult }}
+  </div>
+  <a class="st2-auto-form__link"
+      ui-sref="{{ link }}"
+      ng-if="link">
+    {{ rawResult }}
+  </a>
+</div>

--- a/modules/st2-auto-form/style.less
+++ b/modules/st2-auto-form/style.less
@@ -81,6 +81,29 @@
     }
   }
 
+  &__value {
+    font-weight: normal;
+
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
+    width: 100%;
+    height: 36px;
+    padding: 0 12px;
+
+    cursor: default;
+
+    color: @blue-light;
+    background-color: rgba(54, 64, 73, .65);
+  }
+
+  &__text,
+  &__link {
+    line-height: 36px;
+
+    color: @blue-light;
+  }
+
   &__text-field &__field {
     font: 13px / 18px 'Open Sans', sans-serif;
 

--- a/modules/st2-remote-form/template.html
+++ b/modules/st2-remote-form/template.html
@@ -1,9 +1,15 @@
+<div class="st2-form-text"
+  name="{{name}}"
+  spec="suggestionSpec"
+  ng-model="ngModel[IDENT]"
+  ng-if="disabled">
+</div>
 <div class="st2-manual-form st2-form-combobox"
   name="{{name}}"
   spec="suggestionSpec"
   ng-enums="suggestionSpec.enum"
-  disabled="disabled"
-  ng-model="ngModel[IDENT]">
+  ng-model="ngModel[IDENT]"
+  ng-if="!disabled">
 </div>
 <div ng-switch="form[name].$valid">
   <div class="st2-auto-form__description"

--- a/modules/st2-remote-form/template.html
+++ b/modules/st2-remote-form/template.html
@@ -9,7 +9,8 @@
   spec="suggestionSpec"
   ng-suggestions="suggestionSpec.enum"
   disabled="disabled"
-  ng-model="ngModel[IDENT]">
+  ng-model="ngModel[IDENT]"
+  ng-if="!disabled">
 </div>
 <div ng-switch="form[name].$valid">
   <div class="st2-auto-form__description"


### PR DESCRIPTION
Added a link to actions inside the rule view.

I had to add a directive that shows field values as text instead of disabled inputs. It may be an overkill now, but I’m pretty sure we’ll need it later. Right now the styling just mimics inputs to avoid introducing any more visuals and styles.