### PR TITLE
Putting "rule" subsection (along with enabled checkbox) on top of the edit view

### DIFF
--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -207,6 +207,21 @@
 
         <form name="form">
 
+          <div class="st2-details__panel"
+              ng-show="$root.state.params.edit">
+            <div class="st2-details__panel-heading">
+              <h2 class="st2-details__panel-title">Rule</h2>
+            </div>
+            <div class="st2-details__panel-body">
+
+              <div class="st2-auto-form"
+                spec="metaSpec"
+                ng-model="rule">
+              </div>
+
+            </div>
+          </div>
+
           <div class="st2-details__panel">
             <div class="st2-details__panel-heading">
               <h2 class="st2-details__panel-title">Trigger</h2>
@@ -251,21 +266,6 @@
                   suggester="actionSuggester"
                   loader="actionLoader"
                   ng-model="rule.action">
-              </div>
-
-            </div>
-          </div>
-
-          <div class="st2-details__panel"
-              ng-show="$root.state.params.edit">
-            <div class="st2-details__panel-heading">
-              <h2 class="st2-details__panel-title">Rule</h2>
-            </div>
-            <div class="st2-details__panel-body">
-
-              <div class="st2-auto-form"
-                spec="metaSpec"
-                ng-model="rule">
               </div>
 
             </div>


### PR DESCRIPTION
cc @dzimine 

I think it makes more sense in general to edit rule parameters first when editing a rule. And we put “enabled” checkbox on top that way.