### PR TITLE
Synchronize list of criteria operators

### DIFF
--- a/modules/st2-criteria/directive.js
+++ b/modules/st2-criteria/directive.js
@@ -39,7 +39,9 @@ angular.module('main')
             'td_lt': 'Earlier Than',
             'timediff_lt': 'Earlier Than',
             'td_gt': 'Later Than',
-            'timediff_gt': 'Later Than'
+            'timediff_gt': 'Later Than',
+            'exists': 'Exists',
+            'nexists': "Doesn't Exist"
           },
           required: true
         };


### PR DESCRIPTION
Add missing in WebUI `exists` and `nexists` from [st2 operators](https://github.com/StackStorm/st2/blob/f6e32185ead917e290f6f2489d45460fac5836df/st2common/st2common/operators.py#L187)

See: http://docs.stackstorm.com/latest/rules.html#critera-comparision