### PR TITLE
Fix button appearance in Firefox

### DIFF
--- a/modules/st2-forms/style.less
+++ b/modules/st2-forms/style.less
@@ -16,6 +16,7 @@
     font-family: Oswald;
     font-size: 14px;
     font-weight: 200;
+    line-height: 21px;
 
     position: relative;
 
@@ -51,6 +52,7 @@
       height: 1px;
 
       content: '';
+      -moz-transform: scale(.9999); /* Fixes antialiasing in Firefox on OS X */
 
       border: solid;
       border-width: 16px 10px;


### PR DESCRIPTION
1. Fix diagonal button borders not being antialiased in Firefox on OS X using a hack with `transform: scale` ([Bugzilla link](https://bugzilla.mozilla.org/show_bug.cgi?id=805393))
2. Fix off-by-pixel button height in Firefox by hardcoding `line-height`.

