### PR TITLE
Fix st2-filter sizing

### DIFF
--- a/modules/st2-filter/directive.js
+++ b/modules/st2-filter/directive.js
@@ -6,7 +6,7 @@ angular.module('main')
     return {
       restrict: 'C',
       scope: {
-        defaultLabel: '@label',
+        label: '@label',
         multiple: '@',
         items: '=',
         activeItemsSrc: '=activeItems'
@@ -71,12 +71,7 @@ angular.module('main')
         });
 
         scope.$watch('activeItems', function (activeItems) {
-          scope.label = scope.defaultLabel;
-
-          if (activeItems.length) {
-            activeItems.sort();
-            scope.label += ': ' + activeItems.join(', ');
-          }
+          activeItems.sort();
         });
 
         scope.$watch('search', scope.refreshItemsToShow);

--- a/modules/st2-filter/style.less
+++ b/modules/st2-filter/style.less
@@ -33,12 +33,18 @@
 
     overflow: hidden;
 
-    max-width: 200px;
+    max-width: 170px;
     padding: 0 10px;
 
     cursor: pointer;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    @media (max-width: 1279px) {
+      &-active-items {
+        display: none;
+      }
+    }
 
     &:after {
       font-family: 'ststanley';
@@ -46,7 +52,7 @@
       font-weight: normal;
       font-style: normal;
 
-      display: inline-block;
+      display: inline;
 
       padding-left: 5px;
       // may always broke if we won't pay enough attention to keeping the same codes

--- a/modules/st2-filter/template.html
+++ b/modules/st2-filter/template.html
@@ -1,7 +1,10 @@
 <div class="st2-filter__label"
   ng-class="{'st2-filter__label--active': activeItems.length}"
   ng-click="toggle()">
-  {{ label | capitalize }}
+  {{ label | capitalize }}<!--
+--><span class="st2-filter__label-active-items" ng-show="activeItems.length"><!--
+  -->: {{ activeItems.join(', ') }}
+   </span>
 </div>
 <div class="st2-filter__variants">
   <div class="st2-filter__search" ng-show="items.length > 4">

--- a/modules/st2-panel/style.less
+++ b/modules/st2-panel/style.less
@@ -73,7 +73,7 @@
     color: #fff;
 
     justify-content: space-between;
-    flex-flow: row-reverse wrap;
+    flex-flow: row-reverse nowrap;
 
     &-title {
       font-weight: 400;


### PR DESCRIPTION
Filters now don't disappear if the screen is not wide enough. The chosen item name in a filter label is not shown if the screen width is less than 1280 px. In the worst case scenario, they overlap the title.