### PR TITLE
Fix execution parameters clipping

### DIFF
--- a/apps/st2-history/controller.js
+++ b/apps/st2-history/controller.js
@@ -305,14 +305,11 @@ angular.module('main')
   .filter('fmtParam', function () {
     var fmtParam = function (value) {
       if (_.isString(value)) {
-        return '"' + (value.length < 20 ? value : value.substr(0, 20) + '...') + '"';
+        return '"' + value + '"';
       }
 
       if (_.isArray(value)) {
-        return '[' +
-        _(value).first(3).map(fmtParam).join(', ') +
-        (value.length > 3 ? ',..' : '') +
-        ']';
+        return '[' + _(value).map(fmtParam).join(', ') + ']';
       }
 
       return value;

--- a/apps/st2-history/style.less
+++ b/apps/st2-history/style.less
@@ -74,6 +74,14 @@
     }
   }
 
+  &__column-action-param {
+    display: inline-block;
+    overflow: hidden;
+
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &__column-meta-status {
     word-spacing: 10px;
   }

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -93,18 +93,19 @@
               <span class="st2-history__column-action-name">
                 {{ $root.getRef(record.action) }}
               </span>
-              <span class="st2-history__column-action-params"
-                  ng-if="view.action.subview.params.value"><!--
-            !--><span class="st2-history__column-action-param-name"
-                    ng-repeat-start="(name, value) in record.parameters"><!--
-              !-->{{ name }}=<!--
-            !--></span><!--
-            !--><span class="st2-history__column-action-param-value"><!--
-              !-->{{ value | fmtParam }}<!--
-            !--></span><!--
-            !--><span ng-if="!$last"
-                    ng-repeat-end>, </span><!--
-          !--></span>
+              <span class="st2-history__column-action-params st2-proportional"
+                  ng-if="view.action.subview.params.value">
+                <span class="st2-history__column-action-param"
+                    ng-repeat="(name, value) in record.parameters"><!--
+               --><span ng-if="!$first">,&nbsp;</span><!--
+               --><span class="st2-history__column-action-param-name"><!--
+                 -->{{ name }}=<!--
+               --></span><!--
+               --><span class="st2-history__column-action-param-value"><!--
+                 -->{{ value | fmtParam }}<!--
+               --></span><!--
+             --></span>
+              </span>
             </div>
 
             <div class="st2-flex-table__column st2-history__column-triggered"

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
   <script src="modules/st2-history-child/directive.js"></script>
   <script src="modules/st2-label/directive.js"></script>
   <script src="modules/st2-menu/directive.js"></script>
+  <script src="modules/st2-proportional/directive.js"></script>
   <script src="modules/st2-remote-form/directive.js"></script>
   <script src="modules/st2-report/directive.js"></script>
   <script src="modules/st2-select-on-click/directive.js"></script>

--- a/modules/st2-proportional/directive.js
+++ b/modules/st2-proportional/directive.js
@@ -1,0 +1,73 @@
+'use strict';
+
+angular.module('main')
+  .directive('st2Proportional', function ($window) {
+
+    return {
+      restrict: 'C',
+      link: function postLink(scope, element) {
+        var debouncedMakeProportional = _.debounce(makeProportional, 200).bind(null, element);
+
+        scope.$watch(function() {
+          return element[0].clientWidth;
+        }, debouncedMakeProportional);
+
+        angular.element($window).on('resize', debouncedMakeProportional);
+      }
+    };
+
+    function makeProportional(container) {
+      var children = Array.prototype.slice.call(container.children());
+      var containerStyle = getComputedStyle(container[0]);
+      var childrenWidth = 0;
+      var childrenByWidth = children.map(function(child) {
+        var childWidth;
+
+        if (child.style.width) {
+          child.style.width = '';
+        }
+
+        childWidth = child.offsetWidth;
+        childrenWidth += childWidth;
+        return {
+          element: child,
+          width: childWidth
+        };
+      });
+      var containerWidth = container[0].clientWidth -
+                           parseInt(containerStyle.getPropertyValue('padding-left'), 10) -
+                           parseInt(containerStyle.getPropertyValue('padding-right'), 10);
+      var childrenToShrink = [];
+      var nextChild, freeSpace, newWidth;
+
+      if (childrenWidth <= containerWidth) {
+        return;
+      }
+
+      childrenByWidth.sort(function(a, b) {
+        return b.width - a.width;
+      });
+
+      while (childrenToShrink.length < children.length &&
+             childrenWidth > containerWidth) {
+
+        childrenToShrink.push(childrenByWidth[childrenToShrink.length]);
+        nextChild = childrenByWidth[childrenToShrink.length];
+        newWidth = nextChild ? nextChild.width : containerWidth / children.length;
+
+        /*jshint loopfunc: true */
+        childrenToShrink.forEach(function(child) {
+          child.width = newWidth;
+        });
+        childrenWidth = childrenByWidth.reduce(function(childrenWidth, child) {
+          return childrenWidth + child.width;
+        }, 0);
+      }
+
+      freeSpace = (containerWidth - childrenWidth) / childrenToShrink.length;
+      childrenToShrink.forEach(function(child) {
+        // Currently only works with box-sizing: border-box
+        child.element.style.width = (child.width + freeSpace) + 'px';
+      });
+    }
+  });


### PR DESCRIPTION
In the History list, execution parameters now don't get cut if there is enough space.