### PR TITLE
Show rule definitions as YAML

### DIFF
--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -287,7 +287,7 @@
         ng-class="{'st2-details__body--active': $root.isState('^.code')}">
       <div class="st2-panel__scroller">
 
-        <div class="st2-highlight" code="rule | json" lines="20" language="javascript"></div>
+        <div class="st2-highlight" code="rule | yaml" lines="20" language="yaml"></div>
 
       </div>
     </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,7 @@ var modules = settings.js.map(function (pattern) {
 });
 
 modules.push('node_modules/st2client/dist/st2client.js');
+modules.push('node_modules/yamljs/dist/yaml.min.js');
 
 
 gulp.task('gulphint', function () {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
   <script src="apps/st2-login/controller.js"></script>
   <script src="apps/st2-rules/controller.js"></script>
   <script src="node_modules/st2client/dist/st2client.js"></script>
+  <script src="node_modules/yamljs/dist/yaml.min.js"></script>
   <!-- endbuild -->
   <!-- build:templates -->
   <!-- endbuild -->

--- a/main.js
+++ b/main.js
@@ -106,3 +106,13 @@ angular.module('main')
       }
     };
   });
+
+angular.module('main')
+  .filter('yaml', function () {
+    /*global YAML:true*/
+    return function (input) {
+      if (typeof input !== 'undefined') {
+        return '---\n' + YAML.stringify(input, Infinity, 2);
+      }
+    };
+  });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "main-bower-files": "^2.4.0",
     "mocha": "^1.18.2",
     "protractor": "^1.2.0",
-    "request": "^2.49.0"
+    "request": "^2.49.0",
+    "yamljs": "^0.2.4"
   }
 }


### PR DESCRIPTION
Convert rule definitions to YAML on the fly. This way _all_ rules will be displayed as YAML, but it won't be exactly the same code as in the file. The performance is good, the color scheme needs adjusting.

cc @enykeev @dzimine 