### PR TITLE
Make all routing calls remember filters

### DIFF
--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -140,11 +140,11 @@
             'st2-details__switch--second': $root.isState('^.code')
           }">
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.general', {ref: action.ref})">
+            ng-click="$root.go('^.general', {ref: action.ref})">
           <i class="st2-icon__cogs"></i>
         </div>
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.code', {ref: action.ref})">
+            ng-click="$root.go('^.code', {ref: action.ref})">
           <i class="st2-icon__code"></i>
         </div>
       </div>

--- a/apps/st2-history/controller.js
+++ b/apps/st2-history/controller.js
@@ -275,20 +275,20 @@ angular.module('main')
 
 
       rerun.open = function () {
-        $scope.$root.state.go('^.rerun', {id: $scope.record.id});
+        $scope.$root.go('^.rerun', {id: $scope.record.id});
         rerun.payload = _.clone($scope.payload);
         rerun.actionSpec = $scope.actionSpec;
       };
 
       rerun.cancel = function () {
-        $scope.$root.state.go('^.general', {id: $scope.record.id});
+        $scope.$root.go('^.general', {id: $scope.record.id});
       };
 
       rerun.submit = function () {
         st2api.client.executions.repeat($scope.record.id, {
           parameters: rerun.payload
         }).then(function (record) {
-          $scope.$root.state.go('^.general', {id: record.id});
+          $scope.$root.go('^.general', {id: record.id});
         }).catch(function (error) {
           $scope.rerunform.err = true;
           $scope.$apply();

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -64,7 +64,7 @@
               ng-class-even="'st2-flex-table__row--even'"
               ng-class="{'st2-flex-table__row--active': record.id == $parent.record.id}"
               ng-repeat-start="record in group.records | orderBy:'start_timestamp':true"
-              ng-click="$root.go(_.defaults({id: record.id}, $root.state.params))">
+              ng-click="$root.go({id: record.id})">
 
             <div class="st2-flex-table__column st2-history__column-utility"
                 ng-click="(record | isExpandable) && expand(record, $event)">
@@ -223,11 +223,11 @@
             'st2-details__switch--second': $root.isState('^.code')
           }">
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.general', {id: record.id})">
+            ng-click="$root.go('^.general', {id: record.id})">
           <i class="st2-icon__cogs"></i>
         </div>
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.code', {id: record.id})">
+            ng-click="$root.go('^.code', {id: record.id})">
           <i class="st2-icon__code"></i>
         </div>
       </div>

--- a/apps/st2-rules/controller.js
+++ b/apps/st2-rules/controller.js
@@ -280,7 +280,7 @@ angular.module('main')
       }
 
       st2api.client.rules.delete($scope.rule.ref).then(function () {
-        $scope.$root.state.go('^.list', {}, {reload: true});
+        $scope.$root.go('^.list', {}, {reload: true});
       }).catch(function (error) {
         $scope.form.err = true;
         $scope.$apply();
@@ -291,14 +291,14 @@ angular.module('main')
 
     $scope.popup = {
       open: function () {
-        $scope.$root.state.go('^.new');
+        $scope.$root.go('^.new');
       },
       submit: function () {
         st2api.client.rules.create(angular.copy($scope.newRule)).then(function (rule) {
           $scope.newform.$setPristine();
           $scope.newform.saved = true;
           $scope.$apply();
-          $scope.$root.state.go('^.general', {ref: rule.ref}, {reload: true});
+          $scope.$root.go('^.general', {ref: rule.ref}, {reload: true});
         }).catch(function (error) {
           $scope.newform.err = true;
           $scope.$apply();
@@ -307,7 +307,7 @@ angular.module('main')
         });
       },
       cancel: function () {
-        $scope.$root.state.go('^.list');
+        $scope.$root.go('^.list');
       }
     };
 

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -197,11 +197,11 @@
             'st2-details__switch--second': $root.isState('^.code')
           }">
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.general', $root.state.params)">
+            ng-click="$root.go('^.general', {ref: rule.ref})">
           <i class="st2-icon__cogs"></i>
         </div>
         <div class="st2-details__switch-item"
-            ng-click="$root.state.go('^.code', $root.state.params)">
+            ng-click="$root.go('^.code', {ref: rule.ref})">
           <i class="st2-icon__code"></i>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -37,9 +37,13 @@ angular.module('main')
     $rootScope.state = $state;
     $rootScope._ = _;
 
-    $rootScope.go = function (params, opts) {
-      var isList = $rootScope.state.includes('^.list');
-      return $rootScope.state.go(isList ? '^.general' : '.', params, opts);
+    $rootScope.go = function (state, params, opts) {
+      if (!_.isString(state)) {
+        opts = params;
+        params = state;
+        state = $rootScope.state.includes('^.list') ? '^.general' : '.';
+      }
+      return $rootScope.state.go(state, _.assign({}, $rootScope.state.params, params), opts);
     };
 
     $rootScope.isState = function (states) {

--- a/modules/st2-history-child/template.html
+++ b/modules/st2-history-child/template.html
@@ -23,7 +23,7 @@
       ng-class-even="'st2-flex-table__row--even'"
       ng-class="{'st2-flex-table__row--active': record.id == $root.state.params.id}"
       ng-repeat-start="record in workflow._children | orderBy:'start_timestamp'"
-      ng-click="$root.go($root._.defaults({id: record.id}, $root.state.params))">
+      ng-click="$root.go({id: record.id})">
 
 
     <div class="st2-flex-table__column st2-history__column-utility st2-history-child__column-utility"


### PR DESCRIPTION
The rule of thumb is that unless you specifically want to override the filters, you should never use `$root.state.go`. Consider it low level API.