### PR TITLE
Fix cancellation of rule edit cancellation

### DIFF
--- a/apps/st2-rules/controller.js
+++ b/apps/st2-rules/controller.js
@@ -265,11 +265,12 @@ angular.module('main')
     };
 
     $scope.cancel = function () {
-      $scope.loadRule($scope.rule.ref).then(function () {
-        $scope.form.$setPristine();
-      });
       $scope.$root.go({ref: $scope.rule.ref, edit: undefined}, {
         notify: $scope.form.$dirty
+      }).then(function () {
+        return $scope.loadRule($scope.rule.ref);
+      }).then(function () {
+        $scope.form.$setPristine();
       });
     };
 


### PR DESCRIPTION
BEFORE:
1. Start editing a rule, make some changes
2. Click _Cancel_
3. A confirmation pops up
4. Click _Cancel_ in the dialog
5. The rule edit is not cancelled _(good)_, but the modified fields are reset _(bad)_

NOW:
5. The fields are not reset, the changes are kept, the cancellation is cancelled cancellably.