### PR TITLE
Fix combo boxes not working in the new rule form

### DIFF
--- a/modules/st2-remote-form/template.html
+++ b/modules/st2-remote-form/template.html
@@ -9,7 +9,7 @@
   spec="suggestionSpec"
   ng-suggestions="suggestionSpec.enum"
   disabled="disabled"
-  ng-model="ngModel[IDENT]"
+  ng-model="$parent.ngModel[IDENT]"
   ng-if="!disabled">
 </div>
 <div ng-switch="form[name].$valid">


### PR DESCRIPTION
`Ng-if` creates an isolated scope, so `$parent.` prefix is needed when using `ng-model`.