### PR TITLE
Pack field in rule forms

### DIFF
--- a/apps/st2-rules/controller.js
+++ b/apps/st2-rules/controller.js
@@ -93,13 +93,35 @@ angular.module('main')
         },
         description: {
           type: 'string'
-        },
-        enabled: {
-          type: 'boolean',
-          default: true
         }
       }
     };
+
+    $scope.enabledSpec = {
+      name: 'enabled',
+      type: 'boolean',
+      default: true
+    };
+
+    $scope.packSpec = {
+      name: 'pack',
+      required: true,
+      default: 'default',
+      enum: [{
+        name: 'default',
+        description: 'The default pack'
+      }]
+    };
+
+    st2api.client.packs.list()
+      .then(function (packs) {
+        packs.forEach(function (pack) {
+          $scope.packSpec.enum.push({
+            name: pack.ref,
+            description: pack.description
+          });
+        });
+      });
 
     $scope.newRule = {
       enabled: true

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -32,7 +32,7 @@
 
         <div class="st2-flex-table"
             ng-repeat="(name, params) in groups"
-            ng-if="groups && !_.isEmpty(groups)">
+            ng-if="groups && !_.isEmpty(groups) && !_.isUndefined(params)">
           <div class="st2-flex-table__caption st2-flex-table__caption--pack"
               ng-click="toggle()">
             <img ng-src="{{ icons[name] }}" />

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -299,6 +299,25 @@
                 ng-model="rule">
               </div>
 
+              <div class="st2-form-text"
+                name="pack"
+                spec="packSpec"
+                ng-model="rule.pack"
+                ng-if="!$root.state.params.edit">
+              </div>
+              <div class="st2-manual-form st2-form-combobox"
+                name="pack"
+                spec="packSpec"
+                ng-suggestions="packSpec.enum"
+                ng-model="rule.pack"
+                ng-if="$root.state.params.edit">
+              </div>
+
+              <div class="st2-manual-form st2-form-checkbox"
+                  spec="enabledSpec"
+                  ng-model="rule.enabled">
+              </div>
+
             </div>
           </div>
 
@@ -339,6 +358,18 @@
             <div class="st2-auto-form"
               spec="metaSpec"
               ng-model="newRule">
+            </div>
+
+            <div class="st2-manual-form st2-form-combobox"
+              name="pack"
+              spec="packSpec"
+              ng-suggestions="packSpec.enum"
+              ng-model="newRule.pack">
+            </div>
+
+            <div class="st2-manual-form st2-form-checkbox"
+                spec="enabledSpec"
+                ng-model="newRule.enabled">
             </div>
 
           </div>


### PR DESCRIPTION
The way `st2-form-combobox` is used here is kinda hacky since it cannot be used in an auto form. I think it would be better to make all the inputs independent from `st2-auto-form`, but it's a whole 'nother story. 
Also, combo boxes now allow any values even if they are not in the suggestions. An option for restricting this would be useful.