### PR TITLE
Fix safari variable shadow error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ var modules = settings.js.map(function (pattern) {
 });
 
 modules.push('node_modules/st2client/dist/st2client.js');
-modules.push('node_modules/yamljs/dist/yaml.min.js');
+modules.push('node_modules/yamljs/dist/yaml.js');
 
 
 gulp.task('gulphint', function () {


### PR DESCRIPTION
For some undocumented reason, safari don't like expressions like `function e(e) {}` up to the point it considers them an error. Minified code of one of our dependencies had this code fragment which prevented the wole codebase from being parsed in safari.