### PR TITLE
Support single port deployment

### DIFF
--- a/apps/st2-login/controller.js
+++ b/apps/st2-login/controller.js
@@ -48,7 +48,7 @@ angular.module('main')
     };
 
     $scope.servers = st2Config.hosts;
-    $scope.server = $scope.servers[0];
+    $scope.server = $scope.servers && $scope.servers[0] || { auth: true };
 
     $scope.remember = true;
 

--- a/apps/st2-login/template.html
+++ b/apps/st2-login/template.html
@@ -7,7 +7,8 @@
     <div class="st2-login__error" ng-show="error">
       {{ error }}
     </div>
-    <label class="st2-login__row st2-auto-form__select">
+    <label class="st2-login__row st2-auto-form__select"
+        ng-show="servers">
 
       <select class="st2-auto-form__field st2-login__field"
           ng-model="server"

--- a/modules/st2-api/service.js
+++ b/modules/st2-api/service.js
@@ -7,38 +7,50 @@ angular.module('main')
     this.token = {};
 
     var initClient = function (server, token) {
-      var url = (function () {
-        if (_.find(st2Config.hosts, {url: server.url})) {
-          return server.url;
-        } else {
-          return _.first(st2Config.hosts).url;
-        }
-      })();
+      var opts;
 
-      var api = new URI.parse(url);
+      if (st2Config.hosts) {
+        var url = (function () {
+          if (_.find(st2Config.hosts, {url: server.url})) {
+            return server.url;
+          } else {
+            return _.first(st2Config.hosts).url;
+          }
+        })();
 
-      if (api.port && !api.hostname) {
-        api.hostname = window.location.hostname;
-      }
+        var api = new URI.parse(url);
 
-      var opts = {
-        protocol: api.protocol,
-        host: api.hostname,
-        port: api.port,
-        token: !_.isEmpty(token) ? token : undefined
-      };
-
-      if (server.auth && _.isString(server.auth)) {
-        var auth = URI.parse(server.auth);
-
-        if (auth.port && !auth.hostname) {
-          auth.hostname = window.location.hostname;
+        if (api.port && !api.hostname) {
+          api.hostname = window.location.hostname;
         }
 
-        opts['auth'] = {
-          protocol: auth.protocol,
-          host: auth.hostname,
-          port: auth.port
+        opts = {
+          protocol: api.protocol,
+          host: api.hostname,
+          port: api.port,
+          prefix: api.path,
+          token: !_.isEmpty(token) ? token : undefined
+        };
+
+        if (server.auth && _.isString(server.auth)) {
+          var auth = URI.parse(server.auth);
+
+          if (auth.port && !auth.hostname) {
+            auth.hostname = window.location.hostname;
+          }
+
+          opts['auth'] = {
+            protocol: auth.protocol,
+            host: auth.hostname,
+            port: auth.port,
+            prefix: auth.path
+          };
+        }
+      } else {
+        opts = {
+          api: 'https://' + window.location.hostname + ':443/api',
+          auth: 'https://' + window.location.hostname + ':443/auth',
+          token: !_.isEmpty(token) ? token : undefined
         };
       }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": "stackstorm/st2web",
   "dependencies": {
-    "st2client": "^0.3.9"
+    "st2client": "^0.4.3"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
Removing `hosts` part of config will switch st2web into single port deployment mode.

Unfortunately, removing the whole config is not an option at that point since it will result in an error in web console. There's no way to disable the 404 error from a client side.