### PR TITLE
Ignore reamaze missing

### DIFF
--- a/modules/st2-report/directive.js
+++ b/modules/st2-report/directive.js
@@ -1,13 +1,12 @@
-/* global Reamaze */
 'use strict';
 
 angular.module('main')
-  .directive('st2Report', function () {
+  .directive('st2Report', function ($window) {
 
     return {
       restrict: 'C',
       link: function () {
-        Reamaze.reload();
+        $window.Reamaze && $window.Reamaze.reload();
       }
     };
 


### PR DESCRIPTION
Avoid showing an error when reamaze isn't here for the first digest. It might be a network issue or a race that might be fixed on a second digest.