### PR TITLE
Add global config parameter for flow

### DIFF
--- a/modules/st2-flow/directive.js
+++ b/modules/st2-flow/directive.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('main')
-  .directive('flowLink', function (st2api) {
+  .directive('flowLink', function (st2api, st2Config) {
 
     var parameters = {
       'api': st2api.server.url,
@@ -17,9 +17,9 @@ angular.module('main')
         action: '@'
       },
       link: function (scope, element) {
-        if (st2api.server.flow) {
+        if (st2api.server.flow || st2Config.flow) {
           scope.flow_token = token;
-          scope.flow_url = st2api.server.flow;
+          scope.flow_url = st2api.server.flow || st2Config.flow;
 
           var target = 'st2flow+' + st2api.client.index.url;
 


### PR DESCRIPTION
Right now, you can only define flow on per-host level. With this change you would also be able to define the default one for every host and then rewrite it when necessary.

To set it in config, add `flow: '/flow'` to the st2Config object like that

```js
'use strict';
angular.module('main')
  .constant('st2Config', {

    hosts: [{
      name: 'Dev Env',
      url: '//172.168.50.50:9101'
    }],
    flow: '/flow'

  });
```

or append
```js
angular.module('main').run(function (st2Config) { st2Config.flow = '/flow' });
```
at the bottom of the file.