### PR TITLE
Add vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ debian/st2web
 debian/*.debhelper.log
 debian/*.substvars
 debian/files
+
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.network "public_network"
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = 2048
+    vb.cpus = 2
+  end
+
+  config.vm.provision :shell, :path => "bootstrap.sh"
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+apt-get -y update
+
+# Install N node version manager
+apt-get -y install bash git curl make
+curl -L https://git.io/n-install | su vagrant -c "bash -s -- -y lts"
+
+# Change default CWD to /vagrant
+echo "cd /vagrant" >> /home/vagrant/.bashrc


### PR DESCRIPTION
Although using vagrant for web development will require you to set `allow_origin` manually, it seems like lesser of two evil considering recent npm meltdown.