### PR TITLE
Properly serialize default value to state value string

### DIFF
--- a/modules/st2-auto-form/fields/base.js
+++ b/modules/st2-auto-form/fields/base.js
@@ -79,7 +79,7 @@ export class BaseTextField extends React.Component {
 
     const inputProps = {
       className: 'st2-auto-form__field',
-      placeholder: spec.default,
+      placeholder: this.toStateValue(spec.default),
       disabled: this.props.disabled,
       value: this.state.value,
       onChange: (e) => this.handleChange(e.target.value),
@@ -110,7 +110,7 @@ export class BaseTextareaField extends BaseTextField {
 
     const inputProps = {
       className: 'st2-auto-form__field',
-      placeholder: spec.default,
+      placeholder: this.toStateValue(spec.default),
       disabled: this.props.disabled,
       value: this.state.value,
       onChange: (e) => this.handleChange(e.target.value),

--- a/modules/st2-auto-form/tests/test-array.js
+++ b/modules/st2-auto-form/tests/test-array.js
@@ -62,4 +62,16 @@ describe('AutoForm ArrayField', () => {
     expect(c.fieldClass()).to.have.string('st2-auto-form__field--invalid');
   });
 
+  it('displays default value as serialized json string', () => {
+    const props = {
+      name: 'test',
+      spec: {
+        default: [1,2,3]
+      }
+    };
+
+    const c = new TestComponent(<ArrayField {...props} />);
+
+    expect(c.field().props.placeholder).to.be.equal('1, 2, 3');
+  });
 });

--- a/modules/st2-auto-form/tests/test-object.js
+++ b/modules/st2-auto-form/tests/test-object.js
@@ -58,4 +58,17 @@ describe('AutoForm ObjectField', () => {
 
     expect(c.fieldClass()).to.have.string('st2-auto-form__field--invalid');
   });
+
+  it('displays default value as serialized json string', () => {
+    const props = {
+      name: 'test',
+      spec: {
+        default: {}
+      }
+    };
+
+    const c = new TestComponent(<ObjectField {...props} />);
+
+    expect(c.field().props.placeholder).to.be.equal('{}');
+  });
 });


### PR DESCRIPTION
Failure to do so results in default value of `{}` being represented in a field as `[object object]`.