### PR TITLE
Expand pack when user tries to access the action directly

### DIFF
--- a/apps/st2-actions/actions.controller.js
+++ b/apps/st2-actions/actions.controller.js
@@ -4,7 +4,7 @@ var _ = require('lodash')
   ;
 
 module.exports =
-  function st2ActionsCtrl($scope, st2api, $filter, Notification) {
+  function st2ActionsCtrl($scope, st2api, $filter, Notification, st2FlexTableService) {
 
     $scope.filter = '';
     $scope.error = null;
@@ -105,7 +105,12 @@ module.exports =
     };
 
     $scope.$watch('$root.state.params.ref', function (ref) {
-      var promise = ref ? st2api.client.actionOverview.get(ref) : pActionList.then(function (actions) {
+      var promise = ref ? st2api.client.actionOverview.get(ref).then(function (action) {
+        st2FlexTableService.toggle('actions', action.pack, false);
+        $scope.$apply();
+
+        return action;
+      }) : pActionList.then(function (actions) {
         var first = _.first(actions);
         if (first) {
           return st2api.client.actionOverview.get(first.ref);

--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -40,6 +40,7 @@
             ng-repeat="(name, params) in groups"
             ng-if="groups && !_.isEmpty(groups)"
             ng-class="{'st2-flex-table--collapsed': isCollapsed()}"
+            data-test="pack pack:{{ name }}"
             st2-flex-table-type="actions"
             st2-flex-table-id="{{ name }}">
           <div class="st2-flex-table__caption st2-flex-table__caption--pack"

--- a/tests/test-actions.js
+++ b/tests/test-actions.js
@@ -135,6 +135,11 @@ describe('User visits actions page', function () {
         var element = browser.query(util.name('action:core.announcement'));
         expect(element.className).to.have.string('st2-flex-table__row--active');
       });
+
+      it('should expand the pack', function () {
+        var element = browser.query(util.name('pack:core'));
+        expect(element.className).to.not.have.string('st2-flex-table--collapsed');
+      });
     });
 
     describe('Details view', function () {


### PR DESCRIPTION
By default, we show all the packs collapsed to help user better navigate through the vast amounts of actions modern st2 installation may have.

Although, in case user lands on the page with the URL pointing to the specific action (like in http://192.168.10.26:3000/#/actions/packs.load/general), he likely wants to see this action on the screen and selected.

This PR ensures the pack for currently selected action gets expanded.