### PR TITLE
Merge rerun parameters client-side

### DIFF
--- a/apps/st2-history/history.controller.js
+++ b/apps/st2-history/history.controller.js
@@ -264,7 +264,9 @@ module.exports =
       },
 
       submit: function (parameters) {
-        st2api.client.executions.repeat($scope.record.id, { parameters })
+        st2api.client.executions.repeat($scope.record.id, { parameters }, {
+          no_merge: true
+        })
           .then((record) => {
             $scope.$root.go('^.general', {id: record.id});
           })

--- a/apps/st2-history/rerun-form.component.js
+++ b/apps/st2-history/rerun-form.component.js
@@ -12,8 +12,12 @@ export default class RerunForm extends React.Component {
     onCancel: React.PropTypes.func
   }
 
-  state = {
-    payload: {}
+  constructor(props) {
+    super(props);
+
+    var { payload={} } = props;
+
+    this.state = { payload };
   }
 
   handleChange(name, value) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,7 +2,7 @@
   "name": "st2web",
   "version": "0.0.0",
   "npm-shrinkwrap-version": "200.5.1",
-  "node-version": "v4.4.4",
+  "node-version": "v4.2.2",
   "dependencies": {
     "angular": {
       "version": "1.5.3",
@@ -11088,8 +11088,8 @@
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz"
     },
     "st2client": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/st2client/-/st2client-0.4.4.tgz",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/st2client/-/st2client-0.4.5.tgz",
       "dependencies": {
         "axios": {
           "version": "0.7.0",
@@ -11126,8 +11126,8 @@
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-1.1.1.tgz",
           "dependencies": {
             "object-keys": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react": "0.14.8",
     "react-dom": "0.14.8",
     "react-textarea-autosize": "3.3.1",
-    "st2client": "0.4.4",
+    "st2client": "0.4.5",
     "urijs": "1.17.1",
     "validator": "5.2.0"
   },

--- a/tests/test-history.js
+++ b/tests/test-history.js
@@ -123,7 +123,7 @@ describe('User visits history page', function () {
       return browser.pressButton(util.name('rerun_submit'))
         .then(function () {
           var resource = browser.resources.filter(function (e) {
-            return e.request.method === 'POST' && new RegExp('^https://example.com/api/v1/executions/\\w+/re_run$').test(e.url);
+            return e.request.method === 'POST' && new RegExp('^https://example.com/api/v1/executions/\\w+/re_run\\?no_merge=true$').test(e.url);
           });
 
           expect(resource).to.have.length(1, 'Rerun should make a single request');


### PR DESCRIPTION
This way, user can easily exclude parameters defined in previous runs for them to fallback to default.

Related to https://github.com/StackStorm/st2/pull/2790.