### PR TITLE
Explicit limit and offset for execution calls

### DIFF
--- a/apps/st2-history/history.controller.js
+++ b/apps/st2-history/history.controller.js
@@ -242,7 +242,9 @@ module.exports =
       if (record._expanded) {
         st2api.client.executions.list({
           parent: record.id,
-          exclude_attributes: 'result,trigger_instance'
+          exclude_attributes: 'result,trigger_instance',
+          limit: 0,
+          offset: 0
         }).then(function (records) {
           if (!record._children) {
             record._children = records;


### PR DESCRIPTION
Due to changes in api validation, we're now required to clearly state limit and offset.