### PR TITLE
Update the form on entity change

### DIFF
--- a/apps/st2-actions/template.html
+++ b/apps/st2-actions/template.html
@@ -156,6 +156,7 @@
                 Action has no mutable parameters
               </div>
               <div class="st2-auto-form"
+                key="action.ref"
                 data-test="action_parameters"
                 watch-depth="reference"
                 on-change="onChange"

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -372,6 +372,7 @@
           <div class="st2-details__panel-body">
             <form role="form" class="st2-details__form">
               <div class="st2-auto-form"
+                key="record.action.ref"
                 data-test="action_input"
                 watch-depth="reference"
                 spec="actionSpec"

--- a/apps/st2-rules/template.html
+++ b/apps/st2-rules/template.html
@@ -284,6 +284,7 @@
             <div class="st2-details__panel-body">
 
               <div class="st2-auto-form"
+                key="rule.id"
                 spec="metaSpec"
                 watch-depth="reference"
                 on-change="onChange"

--- a/modules/st2-auto-form/auto-form.component.js
+++ b/modules/st2-auto-form/auto-form.component.js
@@ -11,6 +11,7 @@ import EnumField from './fields/enum';
 
 export default class AutoForm extends React.Component {
   static propTypes = {
+    key: React.PropTypes.string,
     spec: React.PropTypes.object,
     ngModel: React.PropTypes.object,
     disabled: React.PropTypes.bool,

--- a/modules/st2-remote-form/template.html
+++ b/modules/st2-remote-form/template.html
@@ -18,6 +18,7 @@
     Pick valid {{name}} from the list to see its parameters.
   </div>
   <div class="st2-auto-form"
+    key="ngModel[IDENT]"
     spec="formSpec"
     disabled="disabled"
     watch-depth="reference"

--- a/tests/test-actions.js
+++ b/tests/test-actions.js
@@ -211,6 +211,33 @@ describe('User visits actions page', function () {
 
   });
 
+  describe('then selects an action with a specific parameter and fills it', function () {
+    before(function () {
+      return browser
+        .click(util.name('action:core.local'))
+        .then(function () {
+          return browser.fill(util.name('field:cmd'), 'test');
+        })
+        ;
+    });
+
+    it('should have parameter filled', function () {
+      browser.assert.input(util.name('field:cmd'), 'test', 'Field have not been filled');
+    });
+
+    describe('then selects another action with the same parameter', function () {
+      before(function () {
+        return browser
+          .click(util.name('action:core.local_sudo'))
+          ;
+      });
+
+      it('should have empty parameter', function () {
+        browser.assert.input(util.name('field:cmd'), '', 'Field have not been reset');
+      });
+    })
+  })
+
   after(function () {
     browser.tabs.closeAll();
   });


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2/issues/2891.

The problem is related to how react uses virtual DOM to determine which DOM nodes should be updated. Before the change, the only indicator of whether the field should be updated was its name so if we're to switch between two entities having a field with the same name, the element representing the field would not be updated.

In most cases, the field value could still end up being updated due to change in `$scope.payload` object (we set it to `{}` on entity change), but there's two problems with that:
 - one of our dependencies, `react-textarea-autosize` doesn't support this kind of update mechanics and would require us to push the change upstream
 - while we're in transition between angular and react, we're using `ngreact` module to piece them together. The module requires us to define `watch-depth` on the element separating the two. For field value to update, we would need to change `watch-depth` from `reference` to `value` for changes to propagate and it is not clear how it would affect some of our custom fields.

For now, I've decided to set another `key` for the whole form itself which would force it to be redrawn on every entity change. This isn't the prettiest solution, but at the end, this is what we expected to happen all this time anyway.