### PR TITLE
Update rule criteria operators

### DIFF
--- a/modules/st2-criteria/criteria.directive.js
+++ b/modules/st2-criteria/criteria.directive.js
@@ -22,7 +22,9 @@ module.exports =
 
         scope.typeSpec = {
           enum: {
-            'matchregex': 'Matches Regex',
+            'regex': 'Regular expression match',
+            'iregex': 'Case-insensitive regular expression match',
+            'matchwildcard': 'Wildcard match',
             'eq': 'Equals',
             'equals': 'Equals',
             'nequals': 'Not Equals',


### PR DESCRIPTION
The definition was missing new `regex`, `iregex` and `matchwildcard` operators. In addition to that, it still contained deprecated `matchregex` operator.

In the future, we should expose meta / view API in st2 to retrieve available operators so we don't need to hard-code it here (perhaps `GET /v1/rules/views/operators` or similar).

Caught and reported by Lisa Bekdache on Slack.