### PR TITLE
Ignore depreciation of isarray

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platform:
+  npm:
+    isarray:
+      tests:
+        deprecated: skip


### PR DESCRIPTION
Removing isarray would require us to update half of our dependencies. We should do it as a part of the refactoring down the road.