### PR TITLE
Adds newline and wrap buttons to code view

### DIFF
--- a/modules/st2-highlight/highlight.directive.js
+++ b/modules/st2-highlight/highlight.directive.js
@@ -44,6 +44,8 @@ module.exports =
       scope.$watch('code', function (code) {
 
         scope.hidden = true;
+	scope.wrap = false;
+	scope.showNewLines = false;
 
         if (!code) {
           return;
@@ -73,7 +75,9 @@ module.exports =
           }
 
         })();
-
+	
+	scope.newLineString = string.replace(/\\n/g, '\n');
+        scope.unmodifiedString = string;
         var shortString;
 
         if (!scope.full) {
@@ -100,6 +104,14 @@ module.exports =
         }
 
       });
+      scope.toggleNewLines = function() {
+        scope.showNewLines = !scope.showNewLines;
+        if (scope.showNewLines) {
+          fullElement.innerHTML = scope.newLineString;
+        } else {
+          fullElement.innerHTML = scope.unmodifiedString;
+        }
+      };
     }
 
     return {

--- a/modules/st2-highlight/highlight.directive.js
+++ b/modules/st2-highlight/highlight.directive.js
@@ -44,8 +44,8 @@ module.exports =
       scope.$watch('code', function (code) {
 
         scope.hidden = true;
-	scope.wrap = false;
-	scope.showNewLines = false;
+        scope.wrap = false;
+        scope.showNewLines = false;
 
         if (!code) {
           return;
@@ -75,8 +75,8 @@ module.exports =
           }
 
         })();
-	
-	scope.newLineString = string.replace(/\\n/g, '\n');
+  
+      scope.newLineString = string.replace(/\\n/g, '\n');
         scope.unmodifiedString = string;
         var shortString;
 

--- a/modules/st2-highlight/highlight.directive.js
+++ b/modules/st2-highlight/highlight.directive.js
@@ -75,9 +75,11 @@ module.exports =
           }
 
         })();
-  
-      scope.newLineString = string.replace(/\\n/g, '\n');
+
+        scope.newLineString = string.replace(/\\n/g, '\n');
+
         scope.unmodifiedString = string;
+
         var shortString;
 
         if (!scope.full) {

--- a/modules/st2-highlight/style.less
+++ b/modules/st2-highlight/style.less
@@ -104,6 +104,18 @@
     overflow: auto;
   }
 
+  &__fullscreen &__buttons {
+    position: absolute;
+    right: 15px;
+    bottom: 15px;
+
+    display: none;
+  }
+
+  &__fullscreen:hover &__buttons {
+    display: block;
+  }
+
   &__more {
     cursor: pointer;
     text-decoration: underline;

--- a/modules/st2-highlight/style.less
+++ b/modules/st2-highlight/style.less
@@ -127,3 +127,6 @@
     background: none;
   }
 }
+.input--active {
+  background-color: #ff9e1b;
+}

--- a/modules/st2-highlight/style.less
+++ b/modules/st2-highlight/style.less
@@ -28,10 +28,10 @@
 
       &::-webkit-scrollbar-thumb {
         border-radius: 3px;
-        background-color: rgba(200, 200, 200, .3);
+        background-color: rgba(150, 150, 150, .3);
 
         &:hover {
-          background-color: rgba(200, 200, 200, .7);
+          background-color: rgba(150, 150, 150, .7);
         }
       }
 

--- a/modules/st2-highlight/template.html
+++ b/modules/st2-highlight/template.html
@@ -27,8 +27,6 @@
         value="SHOW NEWLINES"
         ng-class="{'input--active': showNewLines}">
     </div>
-    <pre ng-style="{'white-space': (wrap) ? 'pre-wrap' : 'auto'}">
-      <code></code>
-    </pre>
+    <pre ng-style="{'white-space': (wrap) ? 'pre-wrap' : 'auto'}"><code></code></pre>
   </div>
 </div>

--- a/modules/st2-highlight/template.html
+++ b/modules/st2-highlight/template.html
@@ -15,6 +15,16 @@
     ng-click="expand = !expand">
   <div class="st2-highlight__well"
       ng-click="$event.stopPropagation()">
-    <pre><code></code></pre>
+    <input type="button" 
+	ng-click="wrap = !wrap" 
+	value="WRAP LINES"
+	ng-class="{'input--active': wrap}">
+    <input type="button" 
+	ng-click="toggleNewLines()" 
+	value="SHOW NEWLINES"
+	ng-class="{'input--active': showNewLines}">
+    <pre ng-style="{'white-space': (wrap) ? 'pre-wrap' : 'auto'}">
+      <code></code>
+    </pre>
   </div>
 </div>

--- a/modules/st2-highlight/template.html
+++ b/modules/st2-highlight/template.html
@@ -15,16 +15,18 @@
     ng-click="expand = !expand">
   <div class="st2-highlight__well"
       ng-click="$event.stopPropagation()">
-    <input type="button" 
-      class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
-      ng-click="wrap = !wrap" 
-      value="WRAP LINES"
-      ng-class="{'input--active': wrap}">
-    <input type="button" 
-      class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
-      ng-click="toggleNewLines()" 
-      value="SHOW NEWLINES"
-      ng-class="{'input--active': showNewLines}">
+    <div class="st2-highlight__buttons">
+      <input type="button"
+        class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
+        ng-click="wrap = !wrap"
+        value="WRAP LINES"
+        ng-class="{'input--active': wrap}">
+      <input type="button"
+        class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
+        ng-click="toggleNewLines()"
+        value="SHOW NEWLINES"
+        ng-class="{'input--active': showNewLines}">
+    </div>
     <pre ng-style="{'white-space': (wrap) ? 'pre-wrap' : 'auto'}">
       <code></code>
     </pre>

--- a/modules/st2-highlight/template.html
+++ b/modules/st2-highlight/template.html
@@ -16,10 +16,12 @@
   <div class="st2-highlight__well"
       ng-click="$event.stopPropagation()">
     <input type="button" 
+      class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
       ng-click="wrap = !wrap" 
       value="WRAP LINES"
       ng-class="{'input--active': wrap}">
     <input type="button" 
+      class="st2-forms__button st2-forms__button--small st2-details__toolbar-button"
       ng-click="toggleNewLines()" 
       value="SHOW NEWLINES"
       ng-class="{'input--active': showNewLines}">

--- a/modules/st2-highlight/template.html
+++ b/modules/st2-highlight/template.html
@@ -16,13 +16,13 @@
   <div class="st2-highlight__well"
       ng-click="$event.stopPropagation()">
     <input type="button" 
-	ng-click="wrap = !wrap" 
-	value="WRAP LINES"
-	ng-class="{'input--active': wrap}">
+      ng-click="wrap = !wrap" 
+      value="WRAP LINES"
+      ng-class="{'input--active': wrap}">
     <input type="button" 
-	ng-click="toggleNewLines()" 
-	value="SHOW NEWLINES"
-	ng-class="{'input--active': showNewLines}">
+      ng-click="toggleNewLines()" 
+      value="SHOW NEWLINES"
+      ng-class="{'input--active': showNewLines}">
     <pre ng-style="{'white-space': (wrap) ? 'pre-wrap' : 'auto'}">
       <code></code>
     </pre>


### PR DESCRIPTION
Addresses #329 
Allows long lines code view to be wrapped in the window and/or new lines to be rendered to aid in reading output

Before<img width="959" alt="before" src="https://cloud.githubusercontent.com/assets/5100798/25026686/4eb9f932-206d-11e7-9bfc-420ee41f5762.png">

After
<img width="960" alt="after" src="https://cloud.githubusercontent.com/assets/5100798/25026691/5a1cdfe2-206d-11e7-942f-3a606288c98f.png">

