### PR TITLE
Allow Re-Run without parameter modification

### DIFF
--- a/apps/st2-history/history.controller.js
+++ b/apps/st2-history/history.controller.js
@@ -266,7 +266,8 @@ module.exports =
       },
 
       submit: function (parameters) {
-        st2api.client.executions.repeat($scope.record.id, { parameters }, {
+        console.log(parameters);
+        st2api.client.executions.repeat($scope.record.id, { }, {
           no_merge: true
         })
           .then((record) => {

--- a/apps/st2-history/history.controller.js
+++ b/apps/st2-history/history.controller.js
@@ -266,8 +266,7 @@ module.exports =
       },
 
       submit: function (parameters) {
-        console.log(parameters);
-        st2api.client.executions.repeat($scope.record.id, { }, {
+        st2api.client.executions.repeat($scope.record.id, { parameters }, {
           no_merge: true
         })
           .then((record) => {

--- a/apps/st2-history/rerun-form.component.js
+++ b/apps/st2-history/rerun-form.component.js
@@ -17,6 +17,8 @@ export default class RerunForm extends React.Component {
 
     var { payload={} } = props;
 
+    this.original_payload = Object.assign({}, payload);
+
     this.state = { payload };
   }
 
@@ -31,9 +33,18 @@ export default class RerunForm extends React.Component {
   handleSubmit(e) {
     e.preventDefault();
 
+    const state_payload = this.state.payload;
+    let submit_payload = {};
+
+    for (let key of Object.keys(this.original_payload)){
+      if (this.original_payload[key] !== state_payload[key]){
+        submit_payload[key] = state_payload[key];
+      }
+    }
+
     const { onSubmit } = this.props;
 
-    return onSubmit && onSubmit(this.state.payload);
+    return onSubmit && onSubmit(submit_payload);
   }
 
   handleCancel(e) {
@@ -71,7 +82,6 @@ export default class RerunForm extends React.Component {
     };
 
     const autoFormProps = {
-      disabled: true,
       spec: this.props.spec,
       ngModel: this.props.payload,
       onChange: (...args) => this.handleChange(...args)

--- a/apps/st2-history/rerun-form.component.js
+++ b/apps/st2-history/rerun-form.component.js
@@ -71,6 +71,7 @@ export default class RerunForm extends React.Component {
     };
 
     const autoFormProps = {
+      disabled: true,
       spec: this.props.spec,
       ngModel: this.props.payload,
       onChange: (...args) => this.handleChange(...args)


### PR DESCRIPTION
Currently in the web-ui we allow for parameter modification when re-running an action. Since the action's parameters are obfuscated when `secret: true` the obfuscated text is sent in place. We should allow the user to re-run an action without parameter modification which would leave the secret parameters untouched. We shouldn't remove the ability to edit parameters when re-running though so this should be optional when re-running an action.

~- [ ] `Edit Parameters` binary switch~
- [x] Logic to include parameters when ~`edit` binary is `true`~ param is modified.
- [x] Tests

Fixes #364 

### Update:
After toying around with this the way I've implemented seemed to be the right way to go. Basically the workflow is exactly as it used to be, except with we evaluate which params have been modified and only include those in the payload. So if a secret is left alone it is not included and the old param is honored. If a secret field is modified it is included in the payload. This got around an issue I couldn't get over which was "What if someone wants to send ******** as their actual string?". Admittedly a corner case, but this allows them to. This also doesn't change any of the existing logic so it's "mostly" covered by existing tests.