### PR TITLE
Remove Debian wheezy and jessie

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
     version: 4.2.2
   environment:
     DEPLOY_PACKAGES: 1
-    DEB: wheezy jessie trusty xenial
+    DEB: trusty xenial
     RPM: el6 el7
     ST2_TEST_ENVIRONMENT: https://github.com/StackStorm/st2box
     ST2_HOST: localhost
@@ -37,7 +37,7 @@ checkout:
     - git clone --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2box
     - |
         PKG_VERSION=$(node -e "console.log(require('./package.json').st2_version);")
-        PKG_RELEASE=$(packagecloud.sh next-revision wheezy ${PKG_VERSION} st2web)
+        PKG_RELEASE=$(packagecloud.sh next-revision trusty ${PKG_VERSION} st2web)
         echo "export PKG_VERSION=${PKG_VERSION}" >> ~/.circlerc
         echo "export PKG_RELEASE=${PKG_RELEASE}" >> ~/.circlerc
 


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2-packages/issues/365 to remove Debian `wheezy` & `jessie` from the packages builds.