### PR TITLE
Use pack.ref to get pack icon via API

### DIFF
--- a/apps/st2-actions/actions.controller.js
+++ b/apps/st2-actions/actions.controller.js
@@ -78,8 +78,8 @@ module.exports =
           $scope.icons = {};
           _(packs).forEach(function(pack) {
             if (pack.files && pack.files.indexOf('icon.png') >= 0) {
-              var icon_path = st2api.client.packFile.route(pack.name+'/icon.png');
-              $scope.icons[pack.name] = icon_path;
+              var icon_path = st2api.client.packFile.route(pack.ref+'/icon.png');
+              $scope.icons[pack.ref] = icon_path;
             }
           });
           $scope.$apply();

--- a/apps/st2-rules/rules.controller.js
+++ b/apps/st2-rules/rules.controller.js
@@ -69,7 +69,7 @@ module.exports =
       .then(function (packs) {
         packs.forEach(function (pack) {
           $scope.packSpec.enum.push({
-            name: pack.ref,
+            name: pack.name,
             description: pack.description
           });
         });
@@ -116,8 +116,8 @@ module.exports =
           $scope.icons = {};
           _(packs).forEach(function(pack) {
             if (pack.files && pack.files.indexOf('icon.png') >= 0) {
-              var icon_path = st2api.client.packFile.route(pack.name+'/icon.png');
-              $scope.icons[pack.name] = icon_path;
+              var icon_path = st2api.client.packFile.route(pack.ref+'/icon.png');
+              $scope.icons[pack.ref] = icon_path;
             }
           });
           $scope.$apply();


### PR DESCRIPTION
Packs API now uses pack ref as opposed to name
https://github.com/StackStorm/st2/blob/master/st2api/st2api/controllers/v1/packviews.py#L175

But UI was still using pack.name to get the icon. For some of the packs like Circle CI, name is a more user friendly "Circle CI" and ref is "circle_ci". So we should really be using ref to get the icon. 

Pack model defines "ref" as mandatory. So we can assume packs that are being registered will always have "ref" https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/db/pack.py#L43. 

## After

![Actions](https://user-images.githubusercontent.com/1839421/28792627-40a6b074-75fe-11e7-8066-c706ea1e3324.png)

![Rules](https://user-images.githubusercontent.com/1839421/28792629-42805134-75fe-11e7-8c8f-ebed17b12f58.png)


