### PR TITLE
Fixing position sort

### DIFF
--- a/modules/st2-auto-form/auto-form.component.js
+++ b/modules/st2-auto-form/auto-form.component.js
@@ -62,7 +62,7 @@ export default class AutoForm extends React.Component {
         (a, b) => {
           // If position exists for the items we're comparing then lets
           // favor sorting by that
-          if (a.position || b.position){
+          if (a.position !== undefined || b.position !== undefined){
             // Some items might have position undefined. If it's undefined
             // it should be sorted behind an item with position defined
             if (a.position === undefined){


### PR DESCRIPTION
Sorting by position is currently broken because the effective check of:
```
if (0){
}
```

Does not not pass. So we must check if position is explicitly undefined so that we will branch into the sort logic even if the position value is 0.