### PR TITLE
Form should properly handle empty `type: object` field

### DIFF
--- a/modules/st2-auto-form/fields/base.js
+++ b/modules/st2-auto-form/fields/base.js
@@ -35,7 +35,7 @@ export class BaseTextField extends React.Component {
   }
 
   validate(v, spec={}) {
-    if (v === '' && spec.required) {
+    if (v === '' || v === undefined && spec.required) {
       return 'parameter is required';
     }
 
@@ -45,17 +45,19 @@ export class BaseTextField extends React.Component {
   }
 
   getValue() {
-    const invalid = this.validate(this.state.value, this.props.spec);
+    const { value } = this.state;
+    const invalid = this.validate(value, this.props.spec);
 
     if (invalid) {
+      this.setState({ value, invalid });
       throw new Error(invalid);
     }
 
-    if (isJinja(this.state.value)) {
-      return this.state.value;
+    if (isJinja(value)) {
+      return value;
     }
 
-    return this.fromStateValue(this.state.value);
+    return this.fromStateValue(value);
   }
 
   handleChange(value) {

--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -5,7 +5,7 @@ export default class ObjectField extends BaseTextareaField {
   static icon = '{ }'
 
   fromStateValue(v) {
-    return v !== '' ? JSON.parse(v) : void 0;
+    return v !== '' && v !== undefined ? JSON.parse(v) : void 0;
   }
 
   toStateValue(v) {


### PR DESCRIPTION
resolves #404 