### PR TITLE
Stop using ref getter

### DIFF
--- a/apps/st2-actions/actions.controller.js
+++ b/apps/st2-actions/actions.controller.js
@@ -76,7 +76,7 @@ module.exports =
       pActionList && pActionList.then(function (list) {
         $scope.groups = list && _(list)
           .filter(function (action) {
-            var ref = $scope.$root.getRef(action);
+            var ref = action && action.ref;
             return ref.toLowerCase().indexOf($scope.filter.toLowerCase()) > -1;
           })
           .groupBy('pack')
@@ -145,7 +145,7 @@ module.exports =
         $scope.inProgress = true;
 
         st2api.client.executions.list({
-          'action': $scope.$root.getRef(action),
+          'action': action && action.ref,
           'limit': 5,
           'exclude_attributes': 'trigger_instance',
           'parent': 'null'
@@ -240,7 +240,7 @@ module.exports =
     // Running an action
     $scope.runAction = function (action, payload, trace) {
       st2api.client.executions.create({
-        action: $scope.$root.getRef(action),
+        action: action && action.ref,
         parameters: payload,
         context: {
           trace_context: {

--- a/apps/st2-history/template.html
+++ b/apps/st2-history/template.html
@@ -89,10 +89,10 @@
               </div>
 
               <div class="st2-flex-card__column"
-                  title="{{ $root.getRef(record.action) }}"
+                  title="{{ record.action && record.action.ref }}"
                   ng-if="view.action.value">
                 <span class="st2-history__column-action-name">
-                  {{ $root.getRef(record.action) }}
+                  {{ record.action && record.action.ref }}
                 </span>
                 <span class="st2-history__column-action-params st2-proportional"
                     ng-if="view.action.subview.params.value">
@@ -199,8 +199,8 @@
 
     <div class="st2-details__header">
       <div class="st2-details__header-name" data-test="header_name">
-        <a ui-sref="actions.general({ref:$root.getRef(record.action)})">
-          {{ $root.getRef(record.action) }}
+        <a ui-sref="actions.general({ref:record.action.ref})">
+          {{ record.action && record.action.ref }}
         </a>
       </div>
       <div class="st2-details__header-description" data-test="header_description">

--- a/apps/st2-rules/rules.controller.js
+++ b/apps/st2-rules/rules.controller.js
@@ -101,7 +101,7 @@ module.exports =
       pRulesList && pRulesList.then(function (list) {
         $scope.groups = list && _(list)
           .filter(function (rule) {
-            var ref = $scope.$root.getRef(rule);
+            var ref = rule && rule.ref;
             return ref.toLowerCase().indexOf($scope.filter.toLowerCase()) > -1;
           })
           .groupBy('pack')

--- a/main.js
+++ b/main.js
@@ -77,11 +77,6 @@ angular.module('main')
       $rootScope.active_filters = _.pick(params, filters);
     });
 
-    // References
-    $rootScope.getRef = function (entity) {
-      return entity && [entity.pack, entity.name].join('.');
-    };
-
     $rootScope.toggleFlexTables = st2FlexTableService.toggleType.bind(st2FlexTableService);
     $rootScope.areFlexTablesCollapsed = st2FlexTableService.isTypeCollapsed.bind(st2FlexTableService);
   });

--- a/modules/st2-history-child/template.html
+++ b/modules/st2-history-child/template.html
@@ -37,10 +37,10 @@
       </div>
 
       <div class="st2-flex-card__column"
-          title="{{ $root.getRef(record.action) }}"
+          title="{{ record.action && record.action.ref }}"
           ng-if="view.action.value">
         <span class="st2-history__column-action-name">
-          {{ $root.getRef(record.action) }}
+          {{ record.action && record.action.ref }}
         </span>
         <span class="st2-history__column-action-params st2-proportional"
             ng-if="view.action.subview.params.value">


### PR DESCRIPTION
resolves #401 

We still do not recommend switching between tabs too fast as it will create a bunch of network requests that have to be finished before the current view could be resolved. This would create nasty user experience. We'll see what can be done about it after we deprecate Angular parts.