### PR TITLE
Generate URL to api/auth based on current URL

### DIFF
--- a/modules/st2-api/api.service.js
+++ b/modules/st2-api/api.service.js
@@ -51,8 +51,8 @@ module.exports =
         }
       } else {
         opts = {
-          api: 'https://' + window.location.hostname + ':443/api',
-          auth: 'https://' + window.location.hostname + ':443/auth',
+          api: window.location.protocol + '//' + window.location.host + '/api',
+          auth: window.location.protocol + '//' + window.location.host + '/auth',
           token: !_.isEmpty(token) ? token : undefined
         };
       }

--- a/modules/st2-api/api.service.js
+++ b/modules/st2-api/api.service.js
@@ -51,8 +51,8 @@ module.exports =
         }
       } else {
         opts = {
-          api: window.location.protocol + '//' + window.location.host + '/api',
-          auth: window.location.protocol + '//' + window.location.host + '/auth',
+          api: 'https://' + window.location.host + '/api',
+          auth: 'https://' + window.location.host + '/auth',
           token: !_.isEmpty(token) ? token : undefined
         };
       }


### PR DESCRIPTION
When `host` parameter is not set in `config.js` which is by default, st2web will generate url to api/auth endpoint with fixed static `https` protocol and port 443. This behavior makes it a bit complicated when using `st2-docker` image:

- We need to map container port 443 to host 443 port
- or, if we really want to change, then we need to provide custom `config.js` that points to the correct api/auth URL with a mapped port number (like below)

```
'use strict';
angular.module('main')
  .constant('st2Config', {

    hosts: [{
      name: 'default',
      url: 'https://:30443/api',
      auth: 'https://:30443/auth'
    }]
  });
```

This PR will fix this by simply using `window.location` object for protocol and port number to generate endpoint URLs.

Note: I avoided using `window.location.origin` property because of lack of browser support (IE10)