### PR TITLE
st2-auto-form: fix defaults handling

### DIFF
--- a/modules/st2-auto-form/auto-form.component.js
+++ b/modules/st2-auto-form/auto-form.component.js
@@ -128,7 +128,7 @@ function getDefaults(spec) {
 
   Object.keys(spec.properties).forEach((key) => {
     const property = spec.properties[key];
-    if (property.default !== undefined) {
+    if (property.default !== undefined && property.enum) {
       defaults[key] = property.default;
     }
   });

--- a/modules/st2-auto-form/tests/test-component.js
+++ b/modules/st2-auto-form/tests/test-component.js
@@ -68,4 +68,31 @@ describe(`${AutoForm.name} Component`, () => {
 
     expect(onChange.withArgs({ test: 'test' }).calledOnce).to.be.true;
   });
+
+  it('calls an onChange callback as soon as one on the child element gets called', () => {
+    const spec = {
+      properties: {
+        enumed: {
+          default: 'world',
+          enum: [ 'hello', 'world' ],
+        },
+        defaulted: {
+          type: 'string',
+          default: 'foobar',
+        },
+        other: {
+          type: 'string',
+        },
+      },
+    };
+
+    const onChange = sinon.spy();
+
+    const output = ReactTester.create(<AutoForm spec={spec} onChange={onChange} />);
+
+    const [ , , other ] = output.node.props.children;
+    other.props.onChange('test');
+
+    expect(onChange.withArgs({ enumed: 'world', other: 'test' }).calledOnce).to.be.true;
+  });
 });


### PR DESCRIPTION
Without this, some actions (well, at least `core.local`) will error.