### PR TITLE
Fix hardcoded port number to auth/api endpoint URL

### DIFF
--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -65,8 +65,8 @@ export class API {
     }
     else {
       opts = {
-        api: `https://${window.location.hostname}:443/api`,
-        auth: `https://${window.location.hostname}:443/auth`,
+        api: `https://${window.location.host}/api`,
+        auth: `https://${window.location.host}/auth`,
         token: !_.isEmpty(token) ? token : undefined,
       };
     }


### PR DESCRIPTION
There's a regression in 2.6 and some users of docker 1ppc image are facing the problem that they can't login to web UI if that instance is not using port 443 to expose st2web service (which is default for sample kubernetes setup).

This patch will fix it by doing the exact same as https://github.com/StackStorm/st2web/pull/427

