### PR TITLE
Temporary disable scroll into view for executions

### DIFF
--- a/apps/st2-history/history-flex-card.component.js
+++ b/apps/st2-history/history-flex-card.component.js
@@ -69,7 +69,6 @@ export default class HistoryFlexCard extends React.Component {
           })}
           onClick={(e) => this.handleSelect(e)}
           data-test={`execution execution:${execution.id}`}
-          ref={selected === execution.id ? this.context.scrollIntoView : null}
         >
           <div className="st2-flex-card__row">
             <div className="st2-flex-card__column st2-flex-card__expand">


### PR DESCRIPTION
The proper fix itself seems quite involved so I've decided to disable it for now until I can came up with the simpler solution.