### PR TITLE
Open docs/forum links in new tab

### DIFF
--- a/modules/st2-login/login.component.js
+++ b/modules/st2-login/login.component.js
@@ -203,10 +203,10 @@ export default class Login extends React.Component {
           </LoginRow>
 
           <LoginBottomRow>
-            <a target="_blank" rel="noopener noreferrer" href="http://docs.stackstorm.com">
+            <a target="_blank" rel="noopener noreferrer" href="https://docs.stackstorm.com">
               Documentation
             </a>
-            <a href="https://forum.stackstorm.com/">
+            <a target="_blank" rel="noopener noreferrer" href="https://forum.stackstorm.com/">
               Support
             </a>
           </LoginBottomRow>

--- a/modules/st2-menu/menu.component.js
+++ b/modules/st2-menu/menu.component.js
@@ -112,11 +112,11 @@ export default class Menu extends React.Component {
           </label>
         </div>
 
-        <a href="https://docs.stackstorm.com/" className={style.side}>
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.stackstorm.com/" className={style.side}>
           Docs
         </a>
 
-        <a href="https://forum.stackstorm.com/" className={style.side}>
+        <a target="_blank" rel="noopener noreferrer" href="https://forum.stackstorm.com/" className={style.side}>
           Support
         </a>
       </header>


### PR DESCRIPTION
Three related changes here:

1/ Change docs link on login page to use `https:`, save one redirect
2/ Change forum link on login to open in new page, same as docs link
3/ Change forum & docs link on main page to open in new page