### PR TITLE
Make router history a part of the state

### DIFF
--- a/apps/st2-actions/actions-details.component.js
+++ b/apps/st2-actions/actions-details.component.js
@@ -7,7 +7,7 @@ import api from '@stackstorm/module-api';
 import notification from '@stackstorm/module-notification';
 import setTitle from '@stackstorm/module-title';
 
-import { Link } from 'react-router-dom';
+import { Link } from '@stackstorm/module-router';
 import ActionReporter from '@stackstorm/module-action-reporter';
 import AutoForm from '@stackstorm/module-auto-form';
 import StringField from '@stackstorm/module-auto-form/fields/string';

--- a/apps/st2-actions/actions-panel.component.js
+++ b/apps/st2-actions/actions-panel.component.js
@@ -29,6 +29,8 @@ import View from '@stackstorm/module-view';
 import ActionsDetails from './actions-details.component';
 import ActionsFlexCard from './actions-flex-card.component';
 
+import router from '@stackstorm/module-router';
+
 import './style.css';
 
 @connect((state, props) => {
@@ -57,7 +59,6 @@ class FlexTableWrapper extends FlexTable {
 })
 export default class ActionsPanel extends React.Component {
   static propTypes = {
-    history: PropTypes.object,
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
@@ -140,8 +141,7 @@ export default class ActionsPanel extends React.Component {
       return;
     }
 
-    const { history } = this.props;
-    history.push(pathname);
+    router.push({ pathname });
   }
 
   handleSelect(id) {

--- a/apps/st2-actions/actions.component.js
+++ b/apps/st2-actions/actions.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+import { Route } from '@stackstorm/module-router';
 
 import store from './store';
 
@@ -9,9 +10,6 @@ import ActionsPanel from './actions-panel.component';
 
 export default class Actions extends React.Component {
   static propTypes = {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
     routes: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       href: PropTypes.string,
@@ -23,12 +21,19 @@ export default class Actions extends React.Component {
 
   render() {
     return (
-      <Provider store={store}>
-        <div className="wrapper">
-          <Menu location={this.props.location} routes={this.props.routes} />
-          <ActionsPanel {...this.props} />
-        </div>
-      </Provider>
+      <Route
+        path='/actions/:ref?/:section?'
+        render={({ match, location }) => {
+          return (
+            <Provider store={store}>
+              <div className="wrapper">
+                <Menu location={location} routes={this.props.routes} />
+                <ActionsPanel routes={this.props.routes} location={location} match={match} />
+              </div>
+            </Provider>
+          );
+        }}
+      />
     );
   }
 }

--- a/apps/st2-actions/package.json
+++ b/apps/st2-actions/package.json
@@ -58,6 +58,7 @@
     "@stackstorm/module-notification": "^2.0.0",
     "@stackstorm/module-pack-icon": "^2.0.0",
     "@stackstorm/module-panel": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/module-store": "^2.0.0",
     "@stackstorm/module-time": "^2.0.0",
     "@stackstorm/module-title": "^2.0.0",

--- a/apps/st2-history/history-details.component.js
+++ b/apps/st2-history/history-details.component.js
@@ -7,7 +7,7 @@ import api from '@stackstorm/module-api';
 import notification from '@stackstorm/module-notification';
 import setTitle from '@stackstorm/module-title';
 
-import { Link } from 'react-router-dom';
+import { Link } from '@stackstorm/module-router';
 import ActionReporter from '@stackstorm/module-action-reporter';
 import AutoForm from '@stackstorm/module-auto-form';
 import Button from '@stackstorm/module-forms/button.component';

--- a/apps/st2-history/history-panel.component.js
+++ b/apps/st2-history/history-panel.component.js
@@ -36,6 +36,8 @@ import View from '@stackstorm/module-view';
 import HistoryDetails from './history-details.component';
 import HistoryFlexCard from './history-flex-card.component';
 
+import router from '@stackstorm/module-router';
+
 import './style.css';
 
 const PER_PAGE = 50;
@@ -66,7 +68,6 @@ class FlexTableWrapper extends FlexTable {
 })
 export default class HistoryPanel extends React.Component {
   static propTypes = {
-    history: PropTypes.object.isRequired,
     location: PropTypes.shape({
       pathname: PropTypes.string,
       search: PropTypes.string,
@@ -275,8 +276,7 @@ export default class HistoryPanel extends React.Component {
       return;
     }
 
-    const { history } = this.props;
-    history.push(`${pathname}${search}`);
+    router.push({ search, pathname });
   }
 
   handleSelect(id) {

--- a/apps/st2-history/history.component.js
+++ b/apps/st2-history/history.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+import { Route } from '@stackstorm/module-router';
 
 import store from './store';
 
@@ -9,9 +10,6 @@ import HistoryPanel from './history-panel.component';
 
 export default class History extends React.Component {
   static propTypes = {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
     routes: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       href: PropTypes.string,
@@ -23,12 +21,19 @@ export default class History extends React.Component {
 
   render() {
     return (
-      <Provider store={store}>
-        <div className="wrapper">
-          <Menu location={this.props.location} routes={this.props.routes} />
-          <HistoryPanel {...this.props} />
-        </div>
-      </Provider>
+      <Route
+        path='/history/:ref?/:section?'
+        render={({ match, location }) => {
+          return (
+            <Provider store={store}>
+              <div className="wrapper">
+                <Menu location={location} routes={this.props.routes} />
+                <HistoryPanel routes={this.props.routes} location={location} match={match} />
+              </div>
+            </Provider>
+          );
+        }}
+      />
     );
   }
 }

--- a/apps/st2-history/package.json
+++ b/apps/st2-history/package.json
@@ -59,6 +59,7 @@
     "@stackstorm/module-panel": "^2.0.0",
     "@stackstorm/module-popup": "^2.0.0",
     "@stackstorm/module-proportional": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/module-select-on-click": "^2.0.0",
     "@stackstorm/module-store": "^2.0.0",
     "@stackstorm/module-time": "^2.0.0",

--- a/apps/st2-packs/package.json
+++ b/apps/st2-packs/package.json
@@ -54,6 +54,7 @@
     "@stackstorm/module-notification": "^2.0.0",
     "@stackstorm/module-panel": "^2.0.0",
     "@stackstorm/module-portion-bar": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/module-store": "^2.0.0",
     "@stackstorm/module-title": "^2.0.0",
     "insert-css": "2.0.0",

--- a/apps/st2-packs/packs-details.component.js
+++ b/apps/st2-packs/packs-details.component.js
@@ -9,7 +9,7 @@ import apiPacks from './api';
 import notification from '@stackstorm/module-notification';
 import setTitle from '@stackstorm/module-title';
 
-import { Link } from 'react-router-dom';
+import { Link } from '@stackstorm/module-router';
 import AutoForm from '@stackstorm/module-auto-form';
 import Button from '@stackstorm/module-forms/button.component';
 import Highlight from '@stackstorm/module-highlight';

--- a/apps/st2-packs/packs-panel.component.js
+++ b/apps/st2-packs/packs-panel.component.js
@@ -26,6 +26,8 @@ import {
 import PacksDetails from './packs-details.component';
 import PacksFlexCard from './packs-flex-card.component';
 
+import router from '@stackstorm/module-router';
+
 import './style.css';
 
 function waitExecution(execution_id, record) {
@@ -68,7 +70,6 @@ class FlexTableWrapper extends FlexTable {
 })
 export default class PacksPanel extends React.Component {
   static propTypes = {
-    history: PropTypes.object,
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }).isRequired,
@@ -142,8 +143,7 @@ export default class PacksPanel extends React.Component {
       return;
     }
 
-    const { history } = this.props;
-    history.push(pathname);
+    router.push({ pathname });
   }
 
   handleSelect(id) {

--- a/apps/st2-packs/packs.component.js
+++ b/apps/st2-packs/packs.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+import { Route } from '@stackstorm/module-router';
 
 import store from './store';
 
@@ -9,9 +10,6 @@ import PacksPanel from './packs-panel.component';
 
 export default class Packs extends React.Component {
   static propTypes = {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
     routes: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       href: PropTypes.string,
@@ -23,12 +21,19 @@ export default class Packs extends React.Component {
 
   render() {
     return (
-      <Provider store={store}>
-        <div className="wrapper">
-          <Menu location={this.props.location} routes={this.props.routes} />
-          <PacksPanel {...this.props} />
-        </div>
-      </Provider>
+      <Route
+        path='/packs/:ref?/:section?'
+        render={({ history, match, location }) => {
+          return (
+            <Provider store={store}>
+              <div className="wrapper">
+                <Menu location={location} routes={this.props.routes} />
+                <PacksPanel routes={this.props.routes} location={location} match={match} />
+              </div>
+            </Provider>
+          );
+        }}
+      />
     );
   }
 }

--- a/apps/st2-rules/package.json
+++ b/apps/st2-rules/package.json
@@ -58,6 +58,7 @@
     "@stackstorm/module-panel": "^2.0.0",
     "@stackstorm/module-popup": "^2.0.0",
     "@stackstorm/module-remote-form": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/module-store": "^2.0.0",
     "@stackstorm/module-time": "^2.0.0",
     "@stackstorm/module-title": "^2.0.0",

--- a/apps/st2-rules/rules-details.component.js
+++ b/apps/st2-rules/rules-details.component.js
@@ -6,7 +6,7 @@ import api from '@stackstorm/module-api';
 import notification from '@stackstorm/module-notification';
 import setTitle from '@stackstorm/module-title';
 
-import { Link } from 'react-router-dom';
+import { Link } from '@stackstorm/module-router';
 import Criteria from '@stackstorm/module-criteria';
 import Button, { Toggle } from '@stackstorm/module-forms/button.component';
 import Highlight from '@stackstorm/module-highlight';

--- a/apps/st2-rules/rules-panel.component.js
+++ b/apps/st2-rules/rules-panel.component.js
@@ -29,6 +29,8 @@ import RulesFlexCard from './rules-flex-card.component';
 import RulesDetails from './rules-details.component';
 import RulesPopup from './rules-popup.component';
 
+import router from '@stackstorm/module-router';
+
 import './style.css';
 
 @connect((state, props) => {
@@ -58,7 +60,6 @@ class FlexTableWrapper extends FlexTable {
 }))
 export default class RulesPanel extends React.Component {
   static propTypes = {
-    history: PropTypes.object,
     location: PropTypes.shape({
       search: PropTypes.string,
     }),
@@ -172,8 +173,7 @@ export default class RulesPanel extends React.Component {
       return;
     }
 
-    const { history } = this.props;
-    history.push(pathname);
+    router.push({ pathname });
   }
 
   handleSelect(id) {
@@ -192,8 +192,7 @@ export default class RulesPanel extends React.Component {
   }
 
   handleCreatePopup() {
-    const { history } = this.props;
-    history.push('/rules/new');
+    router.push({ pathname: '/rules/new' });
   }
 
   render() {

--- a/apps/st2-rules/rules.component.js
+++ b/apps/st2-rules/rules.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+import { Route } from '@stackstorm/module-router';
 
 import store from './store';
 
@@ -9,9 +10,6 @@ import RulesPanel from './rules-panel.component';
 
 export default class Rules extends React.Component {
   static propTypes = {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
     routes: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       href: PropTypes.string,
@@ -23,12 +21,19 @@ export default class Rules extends React.Component {
 
   render() {
     return (
-      <Provider store={store}>
-        <div className="wrapper">
-          <Menu location={this.props.location} routes={this.props.routes} />
-          <RulesPanel {...this.props} />
-        </div>
-      </Provider>
+      <Route
+        path='/rules/:ref?/:section?'
+        render={({ match, location }) => {
+          return (
+            <Provider store={store}>
+              <div className="wrapper">
+                <Menu location={location} routes={this.props.routes} />
+                <RulesPanel routes={this.props.routes} location={location} match={match} />
+              </div>
+            </Provider>
+          );
+        }}
+      />
     );
   }
 }

--- a/apps/st2-triggers/package.json
+++ b/apps/st2-triggers/package.json
@@ -58,6 +58,7 @@
     "@stackstorm/module-panel": "^2.0.0",
     "@stackstorm/module-popup": "^2.0.0",
     "@stackstorm/module-remote-form": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/module-store": "^2.0.0",
     "@stackstorm/module-time": "^2.0.0",
     "@stackstorm/module-title": "^2.0.0",

--- a/apps/st2-triggers/triggers-details.component.js
+++ b/apps/st2-triggers/triggers-details.component.js
@@ -11,7 +11,7 @@ import api from '@stackstorm/module-api';
 import notification from '@stackstorm/module-notification';
 import setTitle from '@stackstorm/module-title';
 
-import { Link } from 'react-router-dom';
+import { Link } from '@stackstorm/module-router';
 import { Toggle } from '@stackstorm/module-forms/button.component';
 import Highlight from '@stackstorm/module-highlight';
 import {

--- a/apps/st2-triggers/triggers-panel.component.js
+++ b/apps/st2-triggers/triggers-panel.component.js
@@ -26,6 +26,8 @@ import {
 import TriggersFlexCard from './triggers-flex-card.component';
 import TriggersDetails from './triggers-details.component';
 
+import router from '@stackstorm/module-router';
+
 import './style.css';
 
 @connect((state, props) => {
@@ -54,7 +56,6 @@ class FlexTableWrapper extends FlexTable {
 })
 export default class TriggersPanel extends React.Component {
   static propTypes = {
-    history: PropTypes.object,
     location: PropTypes.shape({
       search: PropTypes.string,
     }),
@@ -141,8 +142,7 @@ export default class TriggersPanel extends React.Component {
       return;
     }
 
-    const { history } = this.props;
-    history.push(pathname);
+    router.push({ pathname });
   }
 
   handleSelect(id) {

--- a/apps/st2-triggers/triggers.component.js
+++ b/apps/st2-triggers/triggers.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+import { Route } from '@stackstorm/module-router';
 
 import store from './store';
 
@@ -9,9 +10,6 @@ import TriggersPanel from './triggers-panel.component';
 
 export default class Triggers extends React.Component {
   static propTypes = {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
-    }).isRequired,
     routes: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       href: PropTypes.string,
@@ -23,12 +21,19 @@ export default class Triggers extends React.Component {
 
   render() {
     return (
-      <Provider store={store}>
-        <div className="wrapper">
-          <Menu location={this.props.location} routes={this.props.routes} />
-          <TriggersPanel {...this.props} />
-        </div>
-      </Provider>
+      <Route
+        path='/triggers/:ref?/:section?'
+        render={({ match, location }) => {
+          return (
+            <Provider store={store}>
+              <div className="wrapper">
+                <Menu location={location} routes={this.props.routes} />
+                <TriggersPanel routes={this.props.routes} location={location} match={match} />
+              </div>
+            </Provider>
+          );
+        }}
+      />
     );
   }
 }

--- a/main.js
+++ b/main.js
@@ -1,26 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
-import {
-  Router,
-  Redirect,
-  Route,
-  Switch,
-} from 'react-router-dom';
-import createHashHistory from 'history/createHashHistory';
+import { Provider } from 'react-redux';
 
 import './style.css';
 
-import api from '@stackstorm/module-api';
-import Login from '@stackstorm/module-login';
+import store from '@stackstorm/module-store';
+
+import { Router } from '@stackstorm/module-router';
 
 import Actions from '@stackstorm/app-actions';
 import Triggers from '@stackstorm/app-triggers';
 import History from '@stackstorm/app-history';
 import Packs from '@stackstorm/app-packs';
 import Rules from '@stackstorm/app-rules';
-
-const history = window.routerHistory = createHashHistory({});
 
 const routes = [
   Actions,
@@ -30,44 +22,6 @@ const routes = [
   Rules,
 ];
 
-export class Container extends React.Component {
-  render() {
-    return (
-      <div className="wrapper">
-        <Router history={history}>
-          <Switch>
-            <Route exact path="/" render={() => <Redirect to="/history" />} />
-            { routes.map(({ url, Component }) => {
-              if (!url) {
-                return null;
-              }
 
-              return (
-                <Route
-                  key={url}
-                  path={`${url}/:ref?/:section?`}
-                  render={({ history, match, location }) => {
-                    if (!api.isConnected()) {
-                      return <Login onConnect={() => history.replace()} />;
-                    }
 
-                    return (
-                      <Component
-                        history={history}
-                        match={match}
-                        location={location}
-                        routes={routes}
-                      />
-                    );
-                  }}
-                />
-              );
-            }) }
-          </Switch>
-        </Router>
-      </div>
-    );
-  }
-}
-
-ReactDOM.render(<Container />, document.querySelector('#container'));
+ReactDOM.render(<Provider store={store}><Router routes={routes} /></Provider>, document.querySelector('#container'));

--- a/modules/st2-menu/menu.component.js
+++ b/modules/st2-menu/menu.component.js
@@ -4,7 +4,7 @@ import { PropTypes } from 'prop-types';
 import cx from 'classnames';
 import api from '@stackstorm/module-api';
 
-import { Link } from 'react-router-dom';
+import Link from '@stackstorm/module-router/link.component';
 
 import componentStyle from './style.css';
 

--- a/modules/st2-menu/package.json
+++ b/modules/st2-menu/package.json
@@ -68,7 +68,6 @@
   },
   "peerDependencies": {
     "react": "16.4.1",
-    "react-dom": "16.4.1",
-    "react-router-dom": "4.3.1"
+    "react-dom": "16.4.1"
   }
 }

--- a/modules/st2-notification/notification.js
+++ b/modules/st2-notification/notification.js
@@ -7,6 +7,8 @@ const Noty = (function() {
   return require('noty');
 })();
 
+import router from '@stackstorm/module-router/methods';
+
 import './style.css';
 
 export class Notification {
@@ -27,8 +29,6 @@ export class Notification {
   }
 
   notify(type, text, { buttons = [], err, execution_id, ...options } = {}) {
-    const history = window.routerHistory;
-
     if (err) {
       let expanded = !!execution_id;
       let stack = null;
@@ -63,13 +63,11 @@ export class Notification {
       }
     }
 
-    if (history) {
-      if (execution_id) {
-        buttons.push({
-          text: 'Show execution',
-          onClick: () => history.push(`/history/${execution_id}`),
-        });
-      }
+    if (execution_id) {
+      buttons.push({
+        text: 'Show execution',
+        onClick: () => router.push({ pathname: `/history/${execution_id}` }),
+      });
     }
 
     return new Noty({

--- a/modules/st2-router/history.js
+++ b/modules/st2-router/history.js
@@ -1,0 +1,5 @@
+import createHashHistory from 'history/createHashHistory';
+
+const history = createHashHistory({});
+
+export default history;

--- a/modules/st2-router/index.js
+++ b/modules/st2-router/index.js
@@ -1,0 +1,8 @@
+export { default as Router } from './router.component';
+export { default as Route } from './route.component';
+export { default as Link } from './link.component';
+export { default as Redirect } from './redirect.component';
+
+import methods from './methods';
+
+export default methods;

--- a/modules/st2-router/link.component.js
+++ b/modules/st2-router/link.component.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { createLocation, createPath } from 'history';
+import { connect } from 'react-redux';
+
+import router from '@stackstorm/module-router/methods';
+
+const isModifiedEvent = event =>
+  !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+
+
+@connect(({ location }) => ({ location }))
+export default class Link extends React.Component {
+  static propTypes = {
+    location: PropTypes.object,
+    onClick: PropTypes.func,
+    replace: PropTypes.bool,
+    target: PropTypes.string,
+    to: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]).isRequired,
+    innerRef: PropTypes.oneOfType([ PropTypes.string, PropTypes.func ]),
+  }
+
+  handleClick = event => {
+    if (this.props.onClick) {
+      this.props.onClick(event);
+    }
+
+    if (
+      !event.defaultPrevented && // onClick prevented default
+      event.button === 0 && // ignore everything but left clicks
+      !this.props.target && // let browser handle "target=_blank" etc.
+      !isModifiedEvent(event) // ignore clicks with modifier keys
+    ) {
+      event.preventDefault();
+
+      const { replace, to, location } = this.props;
+
+      const targetLocation =
+        typeof to === 'string'
+          ? createLocation(to, null, null, location)
+          : to;
+
+      if (replace) {
+        router.replace(targetLocation);
+      }
+      else {
+        router.push(targetLocation);
+      }
+    }
+  };
+
+  render() {
+    const { to, innerRef, location, ...props } = this.props;
+
+    props.dispatch = null;
+
+    const targetLocation =
+      typeof to === 'string'
+        ? createLocation(to, null, null, location)
+        : to;
+
+    const href = createPath(targetLocation);
+    
+    return (
+      <a {...props} onClick={this.handleClick} href={href} ref={innerRef} />
+    );
+  }
+}

--- a/modules/st2-router/methods.js
+++ b/modules/st2-router/methods.js
@@ -1,0 +1,18 @@
+import store from '@stackstorm/module-store';
+
+export function updateLocation(target, action) {
+  const { location } = store.getState();
+
+  return store.dispatch({
+    type: 'CHANGE_LOCATION',
+    action,
+    location: { ...location, ...target },
+  });
+}
+
+const methods = {
+  push: (location) => updateLocation(location, 'PUSH'),
+  replace: (location) => updateLocation(location, 'REPLACE'),
+};
+
+export default methods;

--- a/modules/st2-router/package.json
+++ b/modules/st2-router/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@stackstorm/module-store",
+  "name": "@stackstorm/module-router",
   "version": "2.0.0",
   "description": "",
-  "main": "store.js",
+  "main": "index.js",
   "directories": {
     "test": "tests"
   },
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stackstorm/module-router": "^2.0.0",
-    "redux": "3.7.2"
+    "lodash": "4.17.10",
+    "react-router-dom": "4.3.1"
   },
   "devDependencies": {
     "babelify": "8.0.0"

--- a/modules/st2-router/redirect.component.js
+++ b/modules/st2-router/redirect.component.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+import methods from './methods';
+
+export default class Redirect extends React.Component {
+  static propTypes = {
+    push: PropTypes.bool,
+    to: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ]).isRequired,
+  };
+
+  componentDidMount() {
+    this.perform();
+  }
+
+  componentDidUpdate(prevProps) {
+    this.perform();
+  }
+
+  perform() {
+    const { push, to } = this.props;
+
+    if (push) {
+      methods.push({ pathname: to });
+    }
+    else {
+      methods.replace({ pathname: to });
+    }
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/modules/st2-router/reducer.js
+++ b/modules/st2-router/reducer.js
@@ -1,0 +1,14 @@
+export default function reducer(state = {}, action) {
+  state = { ...state };
+
+  switch(action.type) {
+    case 'CHANGE_LOCATION':
+      const { pathname, search='', hash='' } = action.location;
+      state.location = { pathname, search, hash };
+      break;
+    default:
+      break;
+  }
+
+  return state;
+}

--- a/modules/st2-router/route.component.js
+++ b/modules/st2-router/route.component.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { connect } from 'react-redux';
+
+import matchPath from 'react-router/matchPath';
+
+@connect(
+  ({ location }) => ({ location })
+)
+export default class Route extends React.Component {
+  static propTypes = {
+    location: PropTypes.object,
+    path: PropTypes.string.isRequired,
+    render: PropTypes.func.isRequired,
+  }
+
+  render() {
+    const { location, path, render } = this.props;
+    const match =  matchPath(location.pathname, { path });
+    const props = { match, location };
+
+    return match ? render(props) : null;
+  }
+}

--- a/modules/st2-router/router.component.js
+++ b/modules/st2-router/router.component.js
@@ -1,0 +1,82 @@
+import fp from 'lodash/fp';
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { connect } from 'react-redux';
+
+import api from '@stackstorm/module-api';
+import Login from '@stackstorm/module-login';
+import store from '@stackstorm/module-store';
+
+import history from './history';
+import { updateLocation } from './methods';
+import Redirect from './redirect.component';
+
+@connect(
+  ({ location }) => ({ location }),
+  () => ({ updateLocation })
+)
+export default class Router extends React.Component {
+  static propTypes = {
+    routes: PropTypes.array,
+    location: PropTypes.object,
+    updateLocation: PropTypes.func,
+  }
+
+  componentDidMount() {
+    this.unsubscribe = store.subscribe(() => this.handleStateLocationChange());
+    this.unlisten = history.listen((location, action) => this.handleHistoryLocationChange(location, action));
+
+    this.props.updateLocation(history.location, history.action);
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+    this.unlisten();
+  }
+
+  handleStateLocationChange() {
+    const stateLocation = store.getState().location;
+    const historyLocation = fp.pick([ 'pathname', 'search', 'hash' ], history.location);
+
+    if (!fp.isEqual(stateLocation, historyLocation)) {
+      history.push(stateLocation);
+    }
+  }
+
+  handleHistoryLocationChange(location, action) {
+    const stateLocation = store.getState().location;
+    const historyLocation = fp.pick([ 'pathname', 'search', 'hash' ], location);
+
+    if (!fp.isEqual(stateLocation, historyLocation) || action === 'REPLACE') {
+      this.props.updateLocation(historyLocation, action);
+    }
+  }
+
+  render() {
+    const { location, routes } = this.props;
+
+    if (!location) {
+      return null;
+    }
+
+    if (location.pathname === '/') {
+      return <Redirect to="/history" />;
+    }
+
+    if (!api.isConnected()) {
+      return <Login onConnect={() => history.replace()} />;
+    }
+ 
+    for (const { url, Component } of routes) {
+      if (location.pathname.startsWith(url)) {
+        return (
+          <Component
+            routes={routes}
+          />
+        );
+      }
+    }
+
+    return null;
+  }
+}

--- a/modules/st2-store/store.js
+++ b/modules/st2-store/store.js
@@ -1,4 +1,5 @@
 import { createStore, applyMiddleware, compose } from 'redux';
+import routerReducer from '@stackstorm/module-router/reducer';
 
 const PATH_NAME = '__path';
 const ACTION_INIT = '@@st2/INIT';
@@ -15,6 +16,8 @@ const rootReducer = (state = {}, originalAction) => {
       state.routes = (state.routes || []).concat(action.payload);
       break;
     default:
+      state = routerReducer(state, action);
+
       if (path) {
         const { reducer } = scopedStores.find(({ name }) => name === path);
         state[path] = reducer(state[path], action);

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@stackstorm/app-triggers": "^2.0.0",
     "@stackstorm/module-api": "^2.0.0",
     "@stackstorm/module-login": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
     "@stackstorm/st2-style": "^2.0.0",
     "classnames": "2.2.6",
     "insert-css": "2.0.0",
@@ -70,7 +71,6 @@
     "react": "16.4.1",
     "react-dom": "16.4.1",
     "react-redux": "5.0.7",
-    "react-router-dom": "4.3.1",
     "redux": "3.7.2",
     "urijs": "1.19.1"
   },


### PR DESCRIPTION
During the transition to react we also switched to using application state object as a single source of truth. The last major part of that defined state of application outside of storage were browser's address bar (essentially, HTML5 History API).

This PR creates a two-way binding between browser address bar and `location` section of state object  to further consolidate application state in the single place.