### PR TITLE
Code app

### DIFF
--- a/apps/st2-actions/actions-details.component.js
+++ b/apps/st2-actions/actions-details.component.js
@@ -254,7 +254,7 @@ export default class ActionsDetails extends React.Component {
         { section === 'code' ? (
           <DetailsBody>
             <DetailsPanel data-test="action_code">
-              <Highlight code={action} />
+              <Highlight code={action} type="action" id={action.ref} />
             </DetailsPanel>
           </DetailsBody>
         ) : null }

--- a/apps/st2-actions/actions-details.component.js
+++ b/apps/st2-actions/actions-details.component.js
@@ -35,8 +35,8 @@ import {
 import Time from '@stackstorm/module-time';
 
 @connect((state) => {
-  const { action, executions } = state;
-  return { action, executions };
+  const { action, executions, entrypoint } = state;
+  return { action, executions, entrypoint };
 })
 export default class ActionsDetails extends React.Component {
   static propTypes = {
@@ -47,6 +47,7 @@ export default class ActionsDetails extends React.Component {
     section: PropTypes.string,
     action: PropTypes.object,
     executions: PropTypes.array,
+    entrypoint: PropTypes.string,
   }
 
   state = {
@@ -162,6 +163,19 @@ export default class ActionsDetails extends React.Component {
         throw err;
       })
     ;
+
+    store.dispatch({
+      type: 'FETCH_ENTRYPOINT',
+      promise: api.request({
+        path: `/actions/views/entry_point/${id}`,
+        raw: true,
+      }).then(res => res.data),
+    })
+      .catch((err) => {
+        notification.error(`Unable to retrieve entrypoint for action "${id}".`, { err });
+        throw err;
+      })
+    ;
   }
 
   handleSection(section) {
@@ -193,7 +207,7 @@ export default class ActionsDetails extends React.Component {
   }
 
   render() {
-    const { section, action, executions } = this.props;
+    const { section, action, executions, entrypoint } = this.props;
 
     if (!action) {
       return null;
@@ -212,6 +226,7 @@ export default class ActionsDetails extends React.Component {
             { label: 'Parameters', path: 'general' },
             { label: 'executions', path: 'executions' },
             { label: 'Code', path: 'code', className: [ 'icon-code', 'st2-details__switch-button' ] },
+            { label: 'Entrypoint', path: 'entrypoint', className: [ 'icon-code2', 'st2-details__switch-button' ] },
           ]}
           current={section}
           onChange={({ path }) => this.handleSection(path)}
@@ -255,6 +270,14 @@ export default class ActionsDetails extends React.Component {
           <DetailsBody>
             <DetailsPanel data-test="action_code">
               <Highlight code={action} type="action" id={action.ref} />
+            </DetailsPanel>
+          </DetailsBody>
+        ) : null }
+
+        { section === 'entrypoint' ? (
+          <DetailsBody>
+            <DetailsPanel data-test="action_entrypoint">
+              <Highlight code={entrypoint} type="entrypoint" id={action.ref} />
             </DetailsPanel>
           </DetailsBody>
         ) : null }

--- a/apps/st2-actions/actions.component.js
+++ b/apps/st2-actions/actions.component.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Provider } from 'react-redux';
+
+import Menu from '@stackstorm/module-menu';
 import { Route } from '@stackstorm/module-router';
 
 import store from './store';
-
-import Menu from '@stackstorm/module-menu';
 import ActionsPanel from './actions-panel.component';
 
 export default class Actions extends React.Component {

--- a/apps/st2-actions/store.js
+++ b/apps/st2-actions/store.js
@@ -10,6 +10,7 @@ const actionReducer = (state = {}, input) => {
     filter = '',
     action = undefined,
     executions = [],
+    entrypoint = '',
   } = state;
 
   state = {
@@ -19,6 +20,7 @@ const actionReducer = (state = {}, input) => {
     filter,
     action,
     executions,
+    entrypoint,
   };
 
   switch (input.type) {
@@ -72,6 +74,23 @@ const actionReducer = (state = {}, input) => {
       return {
         ...state,
         executions,
+      };
+    }
+
+    case 'FETCH_ENTRYPOINT': {
+      switch(input.status) {
+        case 'success':
+          entrypoint = input.payload;
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        entrypoint,
       };
     }
 

--- a/apps/st2-code/code-panel.component.js
+++ b/apps/st2-code/code-panel.component.js
@@ -1,113 +1,33 @@
-import fp from 'lodash/fp';
 import React from 'react';
 import { PropTypes } from 'prop-types';
 
-import api from '@stackstorm/module-api';
-import Highlight from '@stackstorm/module-highlight';
-
-import style from './style.css';
+import ActionCode from './panels/action-code.component';
+import ActionEntrypoint from './panels/action-entrypoint.component';
+import ExecutionCode from './panels/execution-code.component';
+import ExecutionResult from './panels/execution-result.component';
+import TriggerInstanceCode from './panels/trigger-instance-code.component';
+import UnknownCode from './panels/unknown.component';
 
 export default class CodePanel extends React.Component {
   static propTypes = {
     type: PropTypes.string,
-    id: PropTypes.string,
-  }
-
-  state = {
-    code: '',
-  }
-
-  componentDidMount() {
-    const { type, id } = this.props;
-
-    this.fetch(type, id);
-  }
-
-  componentDidUpdate(prevProps) {
-    const { type, id } = this.props;
-
-    if (!fp.isEqual(prevProps, this.props)) {
-      this.fetch(type, id);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this._stream) {
-      this._stream.close();
-    }
-  }
-
-  async fetch(type, id) {
-    const promise = (async () => {
-      if (type === 'execution') {
-        return api.request({ path: `/executions/${id}` })
-          .then(res => {
-            const code = JSON.stringify(res, null, 2);
-            return { code };
-          });
-      }
-
-      // trigger_instance
-      // trugger_type
-      // rules
-
-      if (type === 'action') {
-        return api.request({ path: `/actions/views/overview/${id}` })
-          .then(res => {
-            const code = JSON.stringify(res, null, 2);
-            return { code };
-          });
-      }
-
-      if (type === 'entrypoint') {
-        return api.request({ path: `/actions/views/entry_point/${id}`, raw: true })
-          .then(res => {
-            return { code: res.data };
-          });
-      }
-
-      if (type === 'result') {
-        if (api.server.stream) {
-          this._stream = await api.listenResults(id, e => this.handlePartialResult(e));
-          
-          return { code: '' };
-        }
-        else {
-          return api.request({ path: `/executions/${id}/output` })
-            .then(res => {
-              return {
-                code: res,
-                warning: 'To see live updates, you need to explicitlty specify Stream URL in your config.js. Relogin after you do.',
-              };
-            });
-        }
-      }
-      
-      return { warning: 'Unknown type' };
-    })();
-    
-    try {
-      const { code, warning } = await promise;
-      this.setState({ code, warning });
-    }
-    catch (e) {
-      this.setState({ code: fp.get('response.data.faultstring', e) });
-    }
-  }
-
-  async handlePartialResult(event) {
-    const partial = JSON.parse(event.data);
-    const { code } = this.state;
-
-    this.setState({ code: `${code || ''}${partial.data}` });
   }
 
   render() {
-    return (
-      <div className={style.component}>
-        { this.state.warning && <div className={style.warning}>{this.state.warning}</div>}
-        <Highlight code={this.state.code} expanded />
-      </div>
-    );
+    const { type } = this.props;
+    switch (type) {
+      case 'action':
+        return <ActionCode {...this.props} />;
+      case 'entrypoint':
+        return <ActionEntrypoint {...this.props} />;
+      case 'execution':
+        return <ExecutionCode {...this.props} />;
+      case 'result':
+        return <ExecutionResult {...this.props} />;
+      case 'trigger_instance':
+        return <TriggerInstanceCode {...this.props} />;
+      default:
+        return <UnknownCode {...this.props} />;
+    }
   }
 }

--- a/apps/st2-code/code-panel.component.js
+++ b/apps/st2-code/code-panel.component.js
@@ -7,6 +7,8 @@ import ExecutionCode from './panels/execution-code.component';
 import ExecutionResult from './panels/execution-result.component';
 import TriggerInstanceCode from './panels/trigger-instance-code.component';
 import LiveFeed from './panels/execution-live-feed.component';
+import RuleCode from './panels/rule-code.component';
+import TriggerTypeCode from './panels/trigger-type-code.component';
 import UnknownCode from './panels/unknown.component';
 
 export default class CodePanel extends React.Component {
@@ -27,6 +29,10 @@ export default class CodePanel extends React.Component {
         return <ExecutionResult {...this.props} />;
       case 'live':
         return <LiveFeed {...this.props} />;
+      case 'rule':
+        return <RuleCode {...this.props} />;
+      case 'trigger_type':
+        return <TriggerTypeCode {...this.props} />;
       case 'trigger_instance':
         return <TriggerInstanceCode {...this.props} />;
       default:

--- a/apps/st2-code/code-panel.component.js
+++ b/apps/st2-code/code-panel.component.js
@@ -6,6 +6,7 @@ import ActionEntrypoint from './panels/action-entrypoint.component';
 import ExecutionCode from './panels/execution-code.component';
 import ExecutionResult from './panels/execution-result.component';
 import TriggerInstanceCode from './panels/trigger-instance-code.component';
+import LiveFeed from './panels/execution-live-feed.component';
 import UnknownCode from './panels/unknown.component';
 
 export default class CodePanel extends React.Component {
@@ -24,6 +25,8 @@ export default class CodePanel extends React.Component {
         return <ExecutionCode {...this.props} />;
       case 'result':
         return <ExecutionResult {...this.props} />;
+      case 'live':
+        return <LiveFeed {...this.props} />;
       case 'trigger_instance':
         return <TriggerInstanceCode {...this.props} />;
       default:

--- a/apps/st2-code/code-panel.component.js
+++ b/apps/st2-code/code-panel.component.js
@@ -105,7 +105,7 @@ export default class CodePanel extends React.Component {
   render() {
     return (
       <div className={style.component}>
-        <div className={style.warning}>{this.state.warning}</div>
+        { this.state.warning && <div className={style.warning}>{this.state.warning}</div>}
         <Highlight code={this.state.code} expanded />
       </div>
     );

--- a/apps/st2-code/code-panel.component.js
+++ b/apps/st2-code/code-panel.component.js
@@ -1,0 +1,96 @@
+import fp from 'lodash/fp';
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+import Highlight from '@stackstorm/module-highlight';
+
+import style from './style.css';
+
+export default class CodePanel extends React.Component {
+  static propTypes = {
+    type: PropTypes.string,
+    id: PropTypes.string,
+  }
+
+  state = {
+    code: '',
+  }
+
+  componentDidMount() {
+    const { type, id } = this.props;
+
+    this.fetch(type, id);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { type, id } = this.props;
+
+    if (!fp.isEqual(prevProps, this.props)) {
+      this.fetch(type, id);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this._stream) {
+      this._stream.close();
+    }
+  }
+
+  async fetch(type, id) {
+    const promise = (() => {
+      if (type === 'execution') {
+        return api.request({ path: `/executions/${id}` })
+          .then(res => JSON.stringify(res, null, 2));
+      }
+
+      // trigger_instance
+      // trugger_type
+      // rules
+
+      if (type === 'action') {
+        return api.request({ path: `/actions/views/overview/${id}` })
+          .then(res => JSON.stringify(res, null, 2));
+      }
+
+      if (type === 'entrypoint') {
+        return api.request({ path: `/actions/views/entry_point/${id}`, raw: true })
+          .then(res => res.data);
+      }
+      // JSON.stringify(res.result, null, 2)
+      if (type === 'result') {
+        return api.request({ path: `/executions/${id}/output`, raw: true })
+          .then(res => res.data);
+      }
+      
+      return 'Unknown type';
+    })();
+    
+    try {
+      const code = await promise;
+      this.setState({ code });
+    }
+    catch (e) {
+      this.setState({ code: fp.get('response.data.faultstring', e) });
+    }
+
+    if (type === 'result') {
+      this._stream = await api.listenEvents('st2.execution.output__create', e => this.handlePartialResult(e));
+    }
+  }
+
+  async handlePartialResult(event) {
+    const partial = JSON.parse(event.data);
+    const { code } = this.state;
+
+    this.setState({ code: `${code || ''}${partial.data}` });
+  }
+
+  render() {
+    return (
+      <div className={style.component}>
+        <Highlight code={this.state.code} expanded />
+      </div>
+    );
+  }
+}

--- a/apps/st2-code/code.component.js
+++ b/apps/st2-code/code.component.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { Route } from '@stackstorm/module-router';
+
+import store from './store';
+import CodePanel from './code-panel.component';
+
+
+export default class Code extends React.Component {
+  render() {
+    return (
+      <Route
+        path='/code/:type?/:ref?'
+        render={({ match, location }) => {
+          return (
+            <Provider store={store}>
+              <CodePanel type={match.params.type} id={match.params.ref} />
+            </Provider>
+          );
+        }}
+      />
+    );
+  }
+}

--- a/apps/st2-code/index.js
+++ b/apps/st2-code/index.js
@@ -1,0 +1,9 @@
+import Code from './code.component';
+
+const route = {
+  title: 'Code',
+  url: '/code',
+  Component: Code,
+};
+
+export default route;

--- a/apps/st2-code/package.json
+++ b/apps/st2-code/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stackstorm/app-code",
+  "version": "2.0.0",
+  "description": "",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackstorm/st2web.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/stackstorm/st2web/issues"
+  },
+  "homepage": "https://github.com/stackstorm/st2web#readme",
+  "browserify": {
+    "transform": [
+      "babelify",
+      [
+        "@stackstorm/browserify-postcss",
+        {
+          "extensions": [
+            ".css"
+          ],
+          "inject": "insert-css",
+          "modularize": {
+            "camelCase": true
+          },
+          "plugin": [
+            "postcss-import",
+            "postcss-nested",
+            [
+              "postcss-preset-env",
+              {
+                "features": {
+                  "custom-properties": {
+                    "preserve": false
+                  }
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@stackstorm/module-highlight": "^2.0.0",
+    "@stackstorm/module-router": "^2.0.0",
+    "insert-css": "2.0.0",
+    "prop-types": "15.6.2"
+  },
+  "devDependencies": {
+    "@stackstorm/browserify-postcss": "0.3.4-patch.5",
+    "babelify": "8.0.0",
+    "postcss": "6.0.22",
+    "postcss-import": "11.1.0",
+    "postcss-nested": "3.0.0",
+    "postcss-preset-env": "5.1.0"
+  },
+  "peerDependencies": {
+    "react": "16.4.1",
+    "react-dom": "16.4.1"
+  }
+}

--- a/apps/st2-code/panels/action-code.component.js
+++ b/apps/st2-code/panels/action-code.component.js
@@ -1,0 +1,34 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class ActionCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    const def = {
+      backUrl: `/actions/${id}/code`,
+    };
+
+    try {
+      const res = await api.request({ path: `/actions/views/overview/${id}` });
+      const code = JSON.stringify(res, null, 2);
+      return {
+        ...def,
+        code,
+      };
+    }
+    catch (e) {
+      return {
+        ...def,
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/action-entrypoint.component.js
+++ b/apps/st2-code/panels/action-entrypoint.component.js
@@ -13,7 +13,7 @@ export default class EntrypointCode extends BaseCode {
 
   async fetch({ id }) {
     const def = {
-      backUrl: `/actions/${id}/code`,
+      backUrl: `/actions/${id}/entrypoint`,
     };
 
     try {

--- a/apps/st2-code/panels/action-entrypoint.component.js
+++ b/apps/st2-code/panels/action-entrypoint.component.js
@@ -1,0 +1,33 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class EntrypointCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    const def = {
+      backUrl: `/actions/${id}/code`,
+    };
+
+    try {
+      const res = await api.request({ path: `/actions/views/entry_point/${id}`, raw: true });
+      return {
+        ...def,
+        code: res.data,
+      };
+    }
+    catch (e) {
+      return {
+        ...def,
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/base.component.js
+++ b/apps/st2-code/panels/base.component.js
@@ -1,0 +1,37 @@
+import fp from 'lodash/fp';
+import React from 'react';
+
+import Highlight from '@stackstorm/module-highlight';
+import { Link } from '@stackstorm/module-router';
+
+import style from '../style.css';
+
+export default class BaseCode extends React.Component {
+  state = {
+    code: '',
+    backUrl: '/history',
+  }
+
+  componentDidMount() {
+    this.fetch(this.props)
+      .then(state => this.setState(state));
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!fp.isEqual(prevProps, this.props)) {
+      this.fetch(this.props)
+        .then(state => this.setState(state));
+    }
+  }
+
+  render() {
+    const { code, warning, backUrl } = this.state;
+    return (
+      <div className={style.component}>
+        <Link to={backUrl} className={style.back}>Back</Link>
+        { this.state.warning && <div className={style.warning}>{ warning }</div>}
+        <Highlight code={code} expanded />
+      </div>
+    );
+  }
+}

--- a/apps/st2-code/panels/execution-code.component.js
+++ b/apps/st2-code/panels/execution-code.component.js
@@ -1,0 +1,34 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class ExecutionCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    const def = {
+      backUrl: `/history/${id}/code`,
+    };
+
+    try {
+      const res = await api.request({ path: `/executions/${id}` });
+      const code = JSON.stringify(res, null, 2);
+      return {
+        ...def,
+        code,
+      };
+    }
+    catch (e) {
+      return {
+        ...def,
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/execution-live-feed.component.js
+++ b/apps/st2-code/panels/execution-live-feed.component.js
@@ -1,0 +1,64 @@
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class LiveFeed extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetchLive({ id }) {
+    const def = {
+      backUrl: `/history/${id}/general`,
+    };
+
+    this._stream = await api.listenResults(id, e => this.handlePartialResult(e));
+      
+    return {
+      ...def,
+      code: '',
+      warning: 'The execution is yet to produce any live output',
+    };
+  }
+
+  async fetchStatic({ id }) {
+    const def = {
+      backUrl: `/history/${id}/general`,
+    };
+
+    const res = await api.request({ path: `/executions/${id}/output` });
+    return {
+      ...def,
+      code: res || '// Action produced no output',
+    };
+  }
+
+  async fetch(props) {
+    if (!api.server.stream) {
+      return {
+        ...await this.fetchStatic(props),
+        warning: 'To see live updates, you need to explicitlty specify Stream URL in your config.js. Relogin after you do.',
+      };
+    }
+
+    return this.fetchLive(props);
+  }
+
+  async handlePartialResult(event) {
+    const partial = JSON.parse(event.data);
+    const { code } = this.state;
+
+    this.setState({ code: `${code || ''}${partial.data}`, warning: false });
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount && super.componentWillUnmount();
+
+    if (this._stream) {
+      this._stream.close();
+    }
+  }
+}

--- a/apps/st2-code/panels/execution-result.component.js
+++ b/apps/st2-code/panels/execution-result.component.js
@@ -1,0 +1,63 @@
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class ResultCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetchLive({ id }) {
+    const def = {
+      backUrl: `/history/${id}/general`,
+    };
+
+    this._stream = await api.listenResults(id, e => this.handlePartialResult(e));
+      
+    return {
+      ...def,
+      code: '',
+    };
+  }
+
+  async fetchStatic({ id }) {
+    const def = {
+      backUrl: `/history/${id}/general`,
+    };
+
+    const res = await api.request({ path: `/executions/${id}/output` });
+    return {
+      ...def,
+      code: res || '// Action produced no data',
+    };
+  }
+
+  async fetch(props) {
+    if (!api.server.stream) {
+      return {
+        ...await this.fetchStatic(props),
+        warning: 'To see live updates, you need to explicitlty specify Stream URL in your config.js. Relogin after you do.',
+      };
+    }
+
+    return this.fetchLive(props);
+  }
+
+  async handlePartialResult(event) {
+    const partial = JSON.parse(event.data);
+    const { code } = this.state;
+
+    this.setState({ code: `${code || ''}${partial.data}` });
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount && super.componentWillUnmount();
+
+    if (this._stream) {
+      this._stream.close();
+    }
+  }
+}

--- a/apps/st2-code/panels/rule-code.component.js
+++ b/apps/st2-code/panels/rule-code.component.js
@@ -1,0 +1,34 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class RuleCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    const def = {
+      backUrl: `/rules/${id}/code`,
+    };
+
+    try {
+      const res = await api.request({ path: `/rules/views/${id}` });
+      const code = JSON.stringify(res, null, 2);
+      return {
+        ...def,
+        code,
+      };
+    }
+    catch (e) {
+      return {
+        ...def,
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/trigger-instance-code.component.js
+++ b/apps/st2-code/panels/trigger-instance-code.component.js
@@ -1,0 +1,31 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class TriggerInstanceCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+    back: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    try {
+      const res = await api.request({ path: `/triggerinstances/${id}` });
+      const code = JSON.stringify(res, null, 2);
+      return {
+        backUrl: `/triggers/${res.trigger}/instances`,
+        code,
+      };
+    }
+    catch (e) {
+      return {
+        backUrl: '/history',
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/trigger-type-code.component.js
+++ b/apps/st2-code/panels/trigger-type-code.component.js
@@ -1,0 +1,34 @@
+import fp from 'lodash/fp';
+import { PropTypes } from 'prop-types';
+
+import api from '@stackstorm/module-api';
+
+import BaseCode from './base.component';
+
+
+export default class TriggerTypeCode extends BaseCode {
+  static propTypes = {
+    id: PropTypes.string,
+  }
+
+  async fetch({ id }) {
+    const def = {
+      backUrl: `/triggers/${id}/code`,
+    };
+
+    try {
+      const res = await api.request({ path: `/triggertypes/${id}` });
+      const code = JSON.stringify(res, null, 2);
+      return {
+        ...def,
+        code,
+      };
+    }
+    catch (e) {
+      return {
+        ...def,
+        code: fp.get('response.data.faultstring', e),
+      };
+    }
+  }
+}

--- a/apps/st2-code/panels/unknown.component.js
+++ b/apps/st2-code/panels/unknown.component.js
@@ -1,0 +1,10 @@
+import BaseCode from './base.component';
+
+export default class UnknownCode extends BaseCode {
+  async fetch({ type }) {
+    return {
+      warning: `Unknown type of code: ${type}`,
+      code: '',
+    };
+  }
+}

--- a/apps/st2-code/store.js
+++ b/apps/st2-code/store.js
@@ -1,0 +1,174 @@
+import _ from 'lodash';
+import { createScopedStore } from '@stackstorm/module-store';
+
+import findIndex from 'lodash/fp/findIndex';
+import set from 'lodash/fp/set';
+
+import flexTableReducer from '@stackstorm/module-flex-table/flex-table.reducer';
+
+const triggerReducer = (state = {}, input) => {
+  let {
+    triggers = [],
+    groups = null,
+    filter = '',
+    trigger = undefined,
+    sensors = {},
+    instances = [],
+  } = state;
+
+  state = {
+    ...state,
+    triggers,
+    groups,
+    filter,
+    trigger,
+    sensors,
+    instances,
+  };
+
+  switch (input.type) {
+    case 'FETCH_GROUPS': {
+      switch(input.status) {
+        case 'success':
+          triggers = input.payload;
+          trigger = trigger && triggers.find(item => item.ref === trigger.ref);
+          groups = makeGroups(triggers, filter);
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        triggers,
+        groups,
+        trigger,
+      };
+    }
+
+    case 'FETCH_SENSORS': {
+      switch(input.status) {
+        case 'success':
+          sensors = {};
+          for (const sensor of input.payload) {
+            for (const trigger of sensor.trigger_types) {
+              sensors[trigger] = sensor;
+            }
+          }
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        sensors,
+      };
+    }
+
+    case 'FETCH_INSTANCES': {
+      switch(input.status) {
+        case 'success':
+          instances = input.payload;
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        instances,
+      };
+    }
+
+    case 'FETCH_ENFORCEMENTS': {
+      switch(input.status) {
+        case 'success':
+          const { id } = input;
+
+          const index = findIndex({ id })(instances);
+
+          if (index > -1) {
+            instances = set(`[${index}].enforcements`, input.payload)(instances);
+          }
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        instances,
+      };
+    }
+
+    case 'TOGGLE_ENABLE': {
+      switch(input.status) {
+        case 'success':
+          for (const trigger of input.payload.trigger_types) {
+            sensors = {
+              ...sensors,
+              [trigger]: {
+                ...input.payload,
+                ref: sensors[trigger].ref,
+              },
+            };
+          }
+          break;
+        case 'error':
+          break;
+        default:
+          break;
+      }
+
+      return {
+        ...state,
+        sensors,
+      };
+    }
+
+    case 'SET_FILTER': {
+      filter = input.filter;
+      groups = makeGroups(triggers, filter);
+
+      return {
+        ...state,
+        groups,
+        filter,
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+const reducer = (state = {}, action) => {
+  state = flexTableReducer(state, action);
+  state = triggerReducer(state, action);
+
+  return state;
+};
+
+const store = createScopedStore('triggers', reducer);
+
+export default store;
+
+function makeGroups(triggers, filter) {
+  const groups = _(triggers)
+    .filter(({ ref }) => ref.toLowerCase().indexOf(filter.toLowerCase()) > -1)
+    .sortBy('ref')
+    .groupBy('pack')
+    .value()
+  ;
+
+  return Object.keys(groups).map((pack) => ({ pack, triggers: groups[pack] }));
+}

--- a/apps/st2-code/style.css
+++ b/apps/st2-code/style.css
@@ -20,3 +20,28 @@
 
   display: inline-block;
 }
+
+.back {
+  font-family: Roboto,sans-serif;
+  font-size: 16px;
+  font-weight: normal;
+
+  margin-right: 10px;
+
+  &:any-link {
+    color: #000;
+  }
+
+  &:before {
+    font-family: "brocadeicons";
+    font-weight: bold;
+    font-style: normal;
+
+    font-size: 14px;
+
+    width: 100%;
+    margin-right: 0.25em;
+
+    content: "\e973";
+  }
+}

--- a/apps/st2-code/style.css
+++ b/apps/st2-code/style.css
@@ -8,3 +8,15 @@
 
   overflow: auto;
 }
+
+.warning {
+  background-color: #FFEAA8;
+  border: 1px solid #FFC237;
+
+  color: #826200;
+
+  padding: 5px;
+  border-radius: 3px;
+
+  display: inline-block;
+}

--- a/apps/st2-code/style.css
+++ b/apps/st2-code/style.css
@@ -1,0 +1,10 @@
+@import "@stackstorm/st2-style/colors.css";
+
+.component {
+  padding: 10px 20px;
+
+  width: 100%;
+  height: 100%;
+
+  overflow: auto;
+}

--- a/apps/st2-history/history-details.component.js
+++ b/apps/st2-history/history-details.component.js
@@ -207,7 +207,7 @@ export default class HistoryDetails extends React.Component {
                   </DetailsPanelBody>
                   { execution.trigger_instance && execution.trigger_instance.occurrence_time ? (
                     <DetailsPanelBody>
-                      <Highlight code={execution.trigger_instance.payload} />
+                      <Highlight code={execution.trigger_instance.payload} lines={10} type="trigger_instance" id={execution.trigger_instance.id} />
                     </DetailsPanelBody>
                   ) : null }
                 </DetailsPanel>
@@ -236,7 +236,7 @@ export default class HistoryDetails extends React.Component {
           ) : null }
           { section === 'code' ? (
             <DetailsPanel data-test="execution_code">
-              <Highlight lines={20} code={execution} />
+              <Highlight code={execution} type="execution" id={execution.id} />
             </DetailsPanel>
           ) : null }
         </DetailsBody>

--- a/apps/st2-history/history-details.component.js
+++ b/apps/st2-history/history-details.component.js
@@ -163,7 +163,11 @@ export default class HistoryDetails extends React.Component {
                     </DetailsPanelBodyLine>
                   ) : null }
                 </DetailsPanelBody>
-                <DetailsPanelHeading title="Action Output" />
+                <DetailsPanelHeading title="Action Output">
+                  <Link to={`/code/live/${execution.id}`} className="st2-history__live-link">
+                    check live output
+                  </Link>
+                </DetailsPanelHeading>
                 <DetailsPanelBody data-test="action_output">
                   <ActionReporter runner={execution.runner.name} execution={execution} />
                 </DetailsPanelBody>
@@ -207,7 +211,7 @@ export default class HistoryDetails extends React.Component {
                   </DetailsPanelBody>
                   { execution.trigger_instance && execution.trigger_instance.occurrence_time ? (
                     <DetailsPanelBody>
-                      <Highlight code={execution.trigger_instance.payload} lines={10} type="trigger_instance" id={execution.trigger_instance.id} />
+                      <Highlight code={execution.trigger_instance.payload} lines={10} type="trigger_instance" id={execution.trigger_instance.id} well />
                     </DetailsPanelBody>
                   ) : null }
                 </DetailsPanel>

--- a/apps/st2-history/history-flex-card.component.js
+++ b/apps/st2-history/history-flex-card.component.js
@@ -60,6 +60,10 @@ export default class HistoryFlexCard extends React.Component {
       handleToggleUTC,
     } = this.props;
 
+    if (!execution || !view.meta) {
+      return false;
+    }
+
     const expanded = !!childExecutions[execution.id];
 
     return [

--- a/apps/st2-history/style.css
+++ b/apps/st2-history/style.css
@@ -159,4 +159,9 @@
     background: #151a1e;
   }
 
+  &__live-link:any-link {
+    cursor: pointer;
+    text-decoration: underline;
+    color: #888;
+  }
 }

--- a/apps/st2-rules/panels/enforcements.js
+++ b/apps/st2-rules/panels/enforcements.js
@@ -125,7 +125,7 @@ export default class EnforcementPanel extends DetailsPanel {
                     }
                   </FlexTableInsertColumn>
                   <FlexTableInsertColumn>
-                    <Highlight well lines={20} code={get('trigger_instance.payload', enforcement)} />
+                    <Highlight well lines={20} code={get('trigger_instance.payload', enforcement)} type="trigger_instance" id={get('trigger_instance.id', enforcement)} />
                   </FlexTableInsertColumn>
                 </FlexTableInsert>,
               ]) }

--- a/apps/st2-rules/rules-details.component.js
+++ b/apps/st2-rules/rules-details.component.js
@@ -508,7 +508,7 @@ export default class RulesDetails extends React.Component {
           ) : null }
           { section === 'code' ? (
             <DetailsPanel data-test="rule_code">
-              <Highlight lines={20} code={rule} />
+              <Highlight code={rule} type="rule" id={rule.id} />
             </DetailsPanel>
           ) : null }
           { section === 'enforcements' ? (

--- a/apps/st2-triggers/panels/instances.js
+++ b/apps/st2-triggers/panels/instances.js
@@ -102,7 +102,7 @@ export default class InstancePanel extends DetailsPanel {
                     }
                   </FlexTableInsertColumn>
                   <FlexTableInsertColumn>
-                    <Highlight well lines={20} code={instance.payload} />
+                    <Highlight well lines={20} code={instance.payload} type="trigger_instance" id={instance.id} />
                   </FlexTableInsertColumn>
                 </FlexTableInsert>,
               ]) }

--- a/apps/st2-triggers/triggers-details.component.js
+++ b/apps/st2-triggers/triggers-details.component.js
@@ -177,7 +177,7 @@ export default class TriggersDetails extends React.Component {
           ) : null }
           { section === 'code' ? (
             <DetailsPanel data-test="trigger_code">
-              <Highlight lines={20} code={trigger} />
+              <Highlight code={trigger} type="trigger_type" id={trigger.ref}/>
             </DetailsPanel>
           ) : null }
           { section === 'instances' ? (

--- a/apps/st2-triggers/triggers-details.component.js
+++ b/apps/st2-triggers/triggers-details.component.js
@@ -177,7 +177,7 @@ export default class TriggersDetails extends React.Component {
           ) : null }
           { section === 'code' ? (
             <DetailsPanel data-test="trigger_code">
-              <Highlight code={trigger} type="trigger_type" id={trigger.ref}/>
+              <Highlight code={trigger} type="trigger_type" id={trigger.ref} />
             </DetailsPanel>
           ) : null }
           { section === 'instances' ? (

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ angular.module('main')
     //     name: 'Dev Env',
     //     url: 'https://:443/api',
     //     auth: 'https://:443/auth',
+    //     stream: 'https://:443/stream',
     //   },
     //   {
     //     name: 'Express',

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import store from '@stackstorm/module-store';
 import { Router } from '@stackstorm/module-router';
 
 import Actions from '@stackstorm/app-actions';
+import Code from '@stackstorm/app-code';
 import Triggers from '@stackstorm/app-triggers';
 import History from '@stackstorm/app-history';
 import Packs from '@stackstorm/app-packs';
@@ -16,6 +17,7 @@ import Rules from '@stackstorm/app-rules';
 
 const routes = [
   Actions,
+  Code,
   Triggers,
   History,
   Packs,

--- a/modules/st2-action-reporter/reporters/debug.js
+++ b/modules/st2-action-reporter/reporters/debug.js
@@ -4,6 +4,6 @@ import Highlight from '@stackstorm/module-highlight';
 
 export default function debug(execution) {
   return (
-    <Highlight well code={execution.result} type="result" id={execution.id} />
+    <Highlight well lines={20} code={execution.result} type="result" id={execution.id} />
   );
 }

--- a/modules/st2-action-reporter/reporters/debug.js
+++ b/modules/st2-action-reporter/reporters/debug.js
@@ -4,6 +4,6 @@ import Highlight from '@stackstorm/module-highlight';
 
 export default function debug(execution) {
   return (
-    <Highlight well code={execution.result} />
+    <Highlight well code={execution.result} type="result" id={execution.id} />
   );
 }

--- a/modules/st2-action-reporter/reporters/run-local.js
+++ b/modules/st2-action-reporter/reporters/run-local.js
@@ -8,17 +8,17 @@ export default function runLocal(execution) {
   return [
     execution.result && execution.result.stdout ? [
       <div key="output" className={style.source}>Output</div>,
-      <Highlight well className={style.highlight} key="output-code" code={execution.result.stdout} type="result" id={execution.id} />,
+      <Highlight well lines={20} className={style.highlight} key="output-code" code={execution.result.stdout} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.stderr ? [
       <div key="error" className={style.source}>Error</div>,
-      <Highlight well className={style.highlight} key="error-code" code={execution.result.stderr} type="result" id={execution.id} />,
+      <Highlight well lines={20} className={style.highlight} key="error-code" code={execution.result.stderr} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.traceback ? [
       <div key="traceback" className={style.source}>Traceback</div>,
-      <Highlight well className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} type="result" id={execution.id} />,
+      <Highlight well lines={20} className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} type="result" id={execution.id} />,
     ] : null,
 
     !execution.result || (!execution.result.stdout && !execution.result.stderr && !execution.result.traceback) ? (

--- a/modules/st2-action-reporter/reporters/run-local.js
+++ b/modules/st2-action-reporter/reporters/run-local.js
@@ -8,21 +8,21 @@ export default function runLocal(execution) {
   return [
     execution.result && execution.result.stdout ? [
       <div key="output" className={style.source}>Output</div>,
-      <Highlight well className={style.highlight} key="output-code" code={execution.result.stdout} />,
+      <Highlight well className={style.highlight} key="output-code" code={execution.result.stdout} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.stderr ? [
       <div key="error" className={style.source}>Error</div>,
-      <Highlight well className={style.highlight} key="error-code" code={execution.result.stderr} />,
+      <Highlight well className={style.highlight} key="error-code" code={execution.result.stderr} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.traceback ? [
       <div key="traceback" className={style.source}>Traceback</div>,
-      <Highlight well className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} />,
+      <Highlight well className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} type="result" id={execution.id} />,
     ] : null,
 
     !execution.result || (!execution.result.stdout && !execution.result.stderr && !execution.result.traceback) ? (
-      <Highlight well className={style.highlight} key="none" code="// Action produced no data" />
+      <Highlight well className={style.highlight} key="none" code="// Action produced no data" type="result" id={execution.id} />
     ) : null,
   ];
 }

--- a/modules/st2-action-reporter/reporters/run-python.js
+++ b/modules/st2-action-reporter/reporters/run-python.js
@@ -8,22 +8,22 @@ export default function runPython(execution) {
   return [
     execution.result && execution.result.result ? [
       <div key="result" className={style.source}>Result</div>,
-      <Highlight well className={style.highlight} key="result-code" code={execution.result.result} />,
+      <Highlight well lines={20} className={style.highlight} key="result-code" code={execution.result.result} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.stdout ? [
       <div key="output" className={style.source}>Output</div>,
-      <Highlight well className={style.highlight} key="output-code" code={execution.result.stdout} />,
+      <Highlight well lines={20} className={style.highlight} key="output-code" code={execution.result.stdout} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.stderr ? [
       <div key="error" className={style.source}>Error</div>,
-      <Highlight well className={style.highlight} key="error-code" code={execution.result.stderr} />,
+      <Highlight well lines={20} className={style.highlight} key="error-code" code={execution.result.stderr} type="result" id={execution.id} />,
     ] : null,
 
     execution.result && execution.result.traceback ? [
       <div key="traceback" className={style.source}>Traceback</div>,
-      <Highlight well className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} />,
+      <Highlight well lines={20} className={style.highlight} key="traceback-code" code={[ execution.result.error, execution.result.traceback ].join('\n')} type="result" id={execution.id} />,
     ] : null,
 
     !execution.result || (!execution.result.result && !execution.result.stdout && !execution.result.stderr && !execution.result.traceback) ? (

--- a/modules/st2-action-reporter/reporters/run-remote.js
+++ b/modules/st2-action-reporter/reporters/run-remote.js
@@ -19,17 +19,17 @@ export default function runRemote(execution) {
 
       result && result.stdout ? [
         <div key="output" className={style.source}>Output</div>,
-        <Highlight well className={style.highlight} key="output-code" code={result.stdout} />,
+        <Highlight well lines={20} className={style.highlight} key="output-code" code={result.stdout} type="result" id={execution.id} />,
       ] : null,
 
       result && result.stderr ? [
         <div key="error" className={style.source}>Error</div>,
-        <Highlight well className={style.highlight} key="error-code" code={result.stderr} />,
+        <Highlight well lines={20} className={style.highlight} key="error-code" code={result.stderr} type="result" id={execution.id} />,
       ] : null,
 
       result && result.traceback ? [
         <div key="traceback" className={style.source}>Traceback</div>,
-        <Highlight well className={style.highlight} key="traceback-code" code={[ result.error, result.traceback ].join('\n')} />,
+        <Highlight well lines={20} className={style.highlight} key="traceback-code" code={[ result.error, result.traceback ].join('\n')} type="result" id={execution.id} />,
       ] : null,
 
       !result || (!result.result && !result.stderr && !result.stdout && !result.traceback) ? (

--- a/modules/st2-action-reporter/style.css
+++ b/modules/st2-action-reporter/style.css
@@ -25,6 +25,6 @@
   color: var(--grey-base);
 }
 
-.highlight + .highlight {
-  margin-bottom: 20px;
+.source + .highlight {
+  margin-bottom: 5px;
 }

--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -186,25 +186,42 @@ export class API {
       response.requestId = requestId;
     }
 
+    if (raw) {
+      return response;
+    }
+
     if (contentType.indexOf('application/json') !== -1) {
       if (typeof response.body === 'string' || response.body instanceof String) {
         response.body = JSON.parse(response.body);
       }
     }
 
-    if (raw) {
-      return response;
-    }
-
     return response.data;
   }
 
   listen() {
-    return new Promise((resolve, reject) => {
-      const streamUrl = `${this.server.stream || this.server.api}/stream`;
+    const streamUrl = `${this.server.stream || this.server.api}/stream`;
 
+    return _source = _source || this.createStream(streamUrl);
+  }
+
+  async listenEvents(eventnames, callback) {
+    const events = [].concat(eventnames);
+    const streamUrl = `${this.server.stream || this.server.api}/stream?events=${events.join(',')}`;
+
+    const stream = await this.createStream(streamUrl);
+
+    for (const eventName of events) {
+      stream.addEventListener(eventName, callback);
+    }
+
+    return stream;
+  }
+
+  createStream(streamUrl) {
+    return new Promise((resolve, reject) => {
       try {
-        const source = _source = _source || new EventSource(streamUrl, {
+        const source = new EventSource(streamUrl, {
           rejectUnauthorized: this.rejectUnauthorized,
           withCredentials: true,
         });

--- a/modules/st2-highlight/highlight.component.js
+++ b/modules/st2-highlight/highlight.component.js
@@ -115,6 +115,7 @@ export default class Highlight extends React.Component {
     expanded: PropTypes.bool,
     type: PropTypes.string,
     id: PropTypes.string,
+    handle: PropTypes.string,
   };
 
   constructor(props) {
@@ -204,7 +205,7 @@ export default class Highlight extends React.Component {
   }
 
   render() {
-    const { className, code, language, lines, well, expanded, type, id, ...props } = this.props;
+    const { className, code, language, lines, well, expanded, type, id, handle='expand', ...props } = this.props;
     language; lines;
 
     if (!code) {
@@ -222,7 +223,7 @@ export default class Highlight extends React.Component {
               <code ref={(ref) => this.onRefShort(ref)} />
               { type && id ? (
                 <Link to={`/code/${type}/${id}`} className={style.more}>
-                  { this.state.more > 0 ? `+ ${this.state.more} more lines` : 'expand' }
+                  { this.state.more > 0 ? `+ ${this.state.more} more lines` : handle }
                 </Link>
               ) : null }
             </pre>

--- a/modules/st2-highlight/highlight.component.js
+++ b/modules/st2-highlight/highlight.component.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import cx from 'classnames';
-
 import Prism from 'prismjs';
+
+import Link from '@stackstorm/module-router/link.component';
 
 import './editor.css';
 import style from './style.pcss';
@@ -111,6 +112,9 @@ export default class Highlight extends React.Component {
     language: PropTypes.string,
     lines: PropTypes.number,
     well: PropTypes.bool,
+    expanded: PropTypes.bool,
+    type: PropTypes.string,
+    id: PropTypes.string,
   };
 
   constructor(props) {
@@ -119,7 +123,6 @@ export default class Highlight extends React.Component {
     const { wrap, newlines } = JSON.parse(localStorage.getItem('st2Highlight')) || { wrap: false, newlines: false };
 
     this.state = {
-      expanded: false,
       wrap,
       newlines,
     };
@@ -147,7 +150,7 @@ export default class Highlight extends React.Component {
   componentDidMount() {
     this._listener = (event) => {
       if (event.key === 'Escape') {
-        this.setState({ expanded: false });
+        // TODO: BACK?
       }
     };
 
@@ -201,7 +204,7 @@ export default class Highlight extends React.Component {
   }
 
   render() {
-    const { className, code, language, lines, well, ...props } = this.props;
+    const { className, code, language, lines, well, expanded, type, id, ...props } = this.props;
     language; lines;
 
     if (!code) {
@@ -212,39 +215,43 @@ export default class Highlight extends React.Component {
 
     return (
       <div {...props} className={cx(style.component, well && style.welled, className)}>
-        <div className={style.well}>
-          <pre>
-            <code ref={(ref) => this.onRefShort(ref)} />
-            <div className={style.more} onClick={() => this.setState({ expanded: true })}>
-              { this.state.more > 0 ? `+ ${this.state.more} more lines` : 'expand' }
-            </div>
-          </pre>
-        </div>
+        { !expanded ? (
 
-        { this.state.expanded ? (
-          <div className={style.fullscreen} onClick={() => this.setState({ expanded: false })}>
-            <div className={style.well} onClick={(e) => e.stopPropagation()}>
-              <div className={style.buttons}>
-                <input
-                  type="button"
-                  className={cx('st2-forms__button', 'st2-forms__button--small', 'st2-details__toolbar-button', this.state.wrap && style.inputActive)}
-                  onClick={() => this.toggleWrap()}
-                  value="WRAP LINES"
-                />
-                <input
-                  type="button"
-                  className={cx('st2-forms__button', 'st2-forms__button--small', 'st2-details__toolbar-button', this.state.newlines && style.inputActive)}
-                  onClick={() => this.toggleNewlines()}
-                  value="SHOW NEWLINES"
-                />
-              </div>
-
-              <pre key={whiteSpace} style={{ whiteSpace }}>
-                <code ref={(ref) => this.onRefFull(ref)} />
-              </pre>
-            </div>
+          <div className={style.well}>
+            <pre>
+              <code ref={(ref) => this.onRefShort(ref)} />
+              { type && id ? (
+                <Link to={`/code/${type}/${id}`} className={style.more}>
+                  { this.state.more > 0 ? `+ ${this.state.more} more lines` : 'expand' }
+                </Link>
+              ) : null }
+            </pre>
           </div>
-        ) : null }
+
+        ) : (
+
+          <div className={style.well}>
+            <div className={style.buttons}>
+              <input
+                type="button"
+                className={cx('st2-forms__button', 'st2-forms__button--small', 'st2-details__toolbar-button', this.state.wrap && style.inputActive)}
+                onClick={() => this.toggleWrap()}
+                value="WRAP LINES"
+              />
+              <input
+                type="button"
+                className={cx('st2-forms__button', 'st2-forms__button--small', 'st2-details__toolbar-button', this.state.newlines && style.inputActive)}
+                onClick={() => this.toggleNewlines()}
+                value="SHOW NEWLINES"
+              />
+            </div>
+
+            <pre key={whiteSpace} style={{ whiteSpace }}>
+              <code ref={(ref) => this.onRefFull(ref)} />
+            </pre>
+          </div>
+
+        ) }
       </div>
     );
   }

--- a/modules/st2-highlight/style.pcss
+++ b/modules/st2-highlight/style.pcss
@@ -6,8 +6,7 @@
   }
 }
 
-.welled .well,
-.fullscreen .well {
+.welled .well {
   min-height: 20px;
   padding: 4px;
 
@@ -52,80 +51,15 @@
   }
 }
 
-.fullscreen {
-  position: fixed;
-  z-index: 2;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-
-  cursor: pointer;
-
-  color: #f4f4f4;
-  background-color: rgba(0,0,0,.8);
-
-  &:after {
-    font-family: "brocadeicons";
-    font-size: 18px;
-    font-weight: normal;
-    font-style: normal;
-
-    position: absolute;
-    top: 20px;
-    right: 20px;
-
-    display: block;
-
-    padding: 5px;
-
-    content: "\e940";
-
-    color: black;
-    border-radius: 50%;
-    background-color: white;
-  }
-
-  .well {
-    position: absolute;
-    top: 30px;
-    right: 30px;
-    bottom: 30px;
-    left: 30px;
-  
-    box-sizing: border-box;
-    margin: 0;
-  
-    cursor: text;
-  
-    pre,
-    code {
-      box-sizing: border-box;
-      height: 100%;
-    }
-
-    code {
-      overflow: auto;
-    }
-  }
-
-  .buttons {
-    position: absolute;
-    right: 15px;
-    bottom: 15px;
-  
-    display: none;
-  }
-
-  &:hover {
-    .buttons {
-      display: block;
-    }
-  }
-
+.buttons {
+  position: absolute;
+  right: 15px;
+  bottom: 15px;
 }
 
-.more {
+a.more:any-link {
+  display: block;
+
   cursor: pointer;
   text-decoration: underline;
 
@@ -136,6 +70,6 @@
   }
 }
 
-.input-active {
+.buttons.input-active {
   background-color: #ff9e1b;
 }

--- a/modules/st2-panel/panel.component.js
+++ b/modules/st2-panel/panel.component.js
@@ -487,14 +487,16 @@ export class DetailsPanelHeading extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     title: PropTypes.string.isRequired,
+    children: PropTypes.node,
   }
 
   render() {
-    const { className, title, ...props } = this.props;
+    const { className, title, children, ...props } = this.props;
 
     return (
       <div {...props} className={cx('st2-details__panel-heading', className)}>
         <h2 className="st2-details__panel-title">{ title }</h2>
+        <div>{ children }</div>
       </div>
     );
   }

--- a/modules/st2-panel/style.css
+++ b/modules/st2-panel/style.css
@@ -691,6 +691,7 @@
 
       line-height: 21px;
       height: 21px;
+      width: 25px;
 
       overflow: hidden;
 
@@ -702,6 +703,10 @@
         width: 100%;
         height: 21px;
       }
+    }
+
+    &-button[class] + &-button[class] {
+      margin-left: 7px;
     }
 
     &-button&-item {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   ],
   "dependencies": {
     "@stackstorm/app-actions": "^2.0.0",
+    "@stackstorm/app-code": "^2.0.0",
     "@stackstorm/app-history": "^2.0.0",
     "@stackstorm/app-packs": "^2.0.0",
     "@stackstorm/app-rules": "^2.0.0",


### PR DESCRIPTION
A separate application for viewing different kinds of code fragments: entities (Actions, Rules, Executions), entry_point files, execution results and trigger instance payloads.

Previously, we showed them as a full screen pop-up, but since we now want to be able to follow live updates of execution results, the task becomes too heavy for the st2-highlight module itself.

At some point, we may want to even add editor to this app and allow user to edit code directly inside the browser, but this certainly lies outside of scope of this PR. 