### PR TITLE
Make serve a reverse proxy for st2

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -7,10 +7,29 @@ const plugins = require('gulp-load-plugins')(settings.plugins);
 let server;
 
 gulp.task('serve', () => {
+  const st2host = process.env.ST2_HOST || '127.0.0.1';
+  const options = {
+    rejectUnauthorized: false,
+  };
+
   server = gulp.src('.')
     .pipe(plugins.webserver({
       host: '0.0.0.0',
       port: 3000,
+      https: true,
+      proxies: [{
+        source: '/api',
+        target: `https://${st2host}/api`,
+        options,
+      }, {
+        source: '/auth',
+        target: `https://${st2host}/auth`,
+        options,
+      }, {
+        source: '/stream',
+        target: `https://${st2host}/stream`,
+        options,
+      }],
     }));
 
   return server;


### PR DESCRIPTION
To aid during development and make another step towards deprecating config.js, `gulp serve` now mimics reference deployment by serving https and acting as api gateway.