### PR TITLE
Allow PORT environment variable for dev server

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -15,7 +15,7 @@ gulp.task('serve', () => {
   server = gulp.src('.')
     .pipe(plugins.webserver({
       host: '0.0.0.0',
-      port: 3000,
+      port: process.env.PORT || 3000,
       https: true,
       proxies: [{
         source: '/api',


### PR DESCRIPTION
The new st2flow code uses lerna and shares the st2-build code with st2web. As such, both projects need to be able to run at the same time and bind to their own ports. This is my first PR, so please advise on naming conventions, commit description, et al.