### PR TITLE
Include package.meta file in the generated production build/ directory

### DIFF
--- a/tasks/production/index.js
+++ b/tasks/production/index.js
@@ -10,4 +10,5 @@ gulp.task('production', gulp.series([
   'production-scripts',
   'production-styles',
   'production-static',
+  'production-package-metadata',
 ]));

--- a/tasks/production/package-metadata.js
+++ b/tasks/production/package-metadata.js
@@ -8,13 +8,15 @@ const fs = require('fs');
 const path = require('path');
 
 gulp.task('production-package-metadata', (done) => {
-  var result, git_sha, data, file_path;
-  result = child_process.spawnSync('git', ['rev-parse', '--short', 'HEAD']);
+  var result, git_sha, data, file_path, pkg_version;
 
+  result = child_process.spawnSync('git', ['rev-parse', '--short', 'HEAD']);
   git_sha = result.stdout.toString().trim();
 
+  pkg_version = require(path.resolve('./package.json')).st2_version;
+
   data = '[st2web]\n'
-  data += 'version = ' + process.env.PKG_VERSION + '\n';
+  data += 'version = ' + pkg_version + '\n';
   data += 'git_sha = ' + git_sha + '\n';
   data += 'circle_build_url = ' + process.env.ST2_CIRCLE_URL;
 

--- a/tasks/production/package-metadata.js
+++ b/tasks/production/package-metadata.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const gulp = require('gulp');
+const settings = require('../settings.json');
+const plugins = require('gulp-load-plugins')(settings.plugins);
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+gulp.task('production-package-metadata', (done) => {
+  var result, git_sha, data, file_path;
+  result = child_process.spawnSync('git', ['rev-parse', '--short', 'HEAD']);
+
+  git_sha = result.stdout.toString().trim();
+
+  data = '[st2web]\n'
+  data += 'version = ' + process.env.PKG_VERSION + '\n';
+  data += 'git_sha = ' + git_sha + '\n';
+  data += 'circle_build_url = ' + process.env.ST2_CIRCLE_URL;
+
+  file_path = path.join(path.resolve('./build'), 'package.meta');
+
+  fs.writeFileSync(file_path, data);
+  done();
+});


### PR DESCRIPTION
This pull request adds new `production-package-metadata` gulp task which writes `package.meta` file in `build/` directory with various build meta information (which git revision was it built from, which version it refers to).

This will allow us to correlate particular webui bundle on disk to a git revision (right now it's impossible to directly correlate contents on disk to a git revision, afaik and this makes some troubleshooting hard).

I believe we included version in the footer in the past or somewhere else, but it got dropped or similar when we removed reamaze widget.