### PR TITLE
Fixes for st2flow integration

### DIFF
--- a/modules/st2-auto-form/fields/boolean.js
+++ b/modules/st2-auto-form/fields/boolean.js
@@ -24,7 +24,7 @@ export default class BooleanField extends BaseTextField {
     const inputProps = {
       className: 'st2-auto-form__checkbox',
       disabled: this.props.disabled,
-      checked: this.state.value,
+      checked: !this.validate(this.state.value) && this.state.value,
       onChange: (e) => this.handleChange(e, e.target.checked),
     };
 

--- a/modules/st2-auto-form/style.css
+++ b/modules/st2-auto-form/style.css
@@ -55,13 +55,11 @@
 
   &__button {
     font-size: 14px;
-    line-height: 34px;
 
     position: absolute;
     right: 0;
 
-    width: 36px;
-    height: 36px;
+    padding: 11px;
 
     cursor: pointer;
     user-select: none;
@@ -420,7 +418,7 @@
         }
       }
     }
-    
+
     &__description {
       display: none;
     }

--- a/modules/st2-auto-form/tests/test-boolean.js
+++ b/modules/st2-auto-form/tests/test-boolean.js
@@ -52,7 +52,7 @@ describe('AutoForm BooleanField', () => {
 
     expect(onChange.withArgs('invalid')).to.not.be.called;
 
-    expect(c.fieldValue('checked')).to.be.equal('invalid');
+    expect(c.fieldValue('checked')).to.be.equal(false);
   });
 
   it('resets the value when reset button is pressed', () => {

--- a/modules/st2-time/tests/test-time.js
+++ b/modules/st2-time/tests/test-time.js
@@ -38,7 +38,8 @@ describe(`${Time.name} Component`, () => {
     );
 
     // note: this will only work in places with whole hour offsets
-    const hour = (24 - new Date().getTimezoneOffset() / 60);
+    // note2: we use january because it's outside of daylight savings time
+    const hour = (24 - new Date(new Date().getFullYear(), 0, 1).getTimezoneOffset() / 60);
     if (hour >= 24) {
       expect(instance.text).to.equal(
         `Thu, 01 Jan 1970 ${(hour - 24).toFixed(0).padStart(2, '0')}:00:00`
@@ -69,7 +70,8 @@ describe(`${Time.name} Component`, () => {
     );
 
     // note: this will only work in places with whole hour offsets
-    const hour = (24 - new Date().getTimezoneOffset() / 60);
+    // note2: we use january because it's outside of daylight savings time
+    const hour = (24 - new Date(new Date().getFullYear(), 0, 1).getTimezoneOffset() / 60);
     if (hour >= 24) {
       expect(instance.text).to.equal(
         `January 1 1970 ${(hour - 24).toFixed(0).padStart(2, '0')}:00 AM`

--- a/tasks/test-functional.js
+++ b/tasks/test-functional.js
@@ -22,7 +22,7 @@ gulp.task('test-functional', gulp.series([ 'build' ], (done) => {
   return gulp.src(argv['test-files'] || settings.tests, {read: false})
     .pipe(plugins.plumber())
     .pipe(plugins.mocha({
-      reporter: 'spec',
+      reporter: argv.reporter || 'spec',
       require: [
         'babel-register',
       ],

--- a/tasks/test-unit.js
+++ b/tasks/test-unit.js
@@ -9,7 +9,7 @@ const { argv } = require('yargs');
 gulp.task('test-unit', (done) => gulp.src(argv['test-files'] || settings.units, {read: false})
   .pipe(plugins.plumber())
   .pipe(plugins.mocha({
-    reporter: 'dot',
+    reporter: argv.reporter || 'dot',
     require: [
       'babel-register',
       'ignore-styles',


### PR DESCRIPTION
This is a set of changes that allows st2flow to share functionality with st2web. As of right now we are needing to share the `st2-styles` and `st2-auto-form` packages.

NOTE: this PR is tightly coupled to [this PR on st2flow](https://github.com/StackStorm/st2flow/pull/151).

This PR also contains minor changes for the following:
- fix tests for `time` component so they work in regions with daylight savings
- allow `--reporter` flag to be set while running gulp tests