### PR TITLE
BUGFIX - Crash on timeout http action

### DIFF
--- a/modules/st2-action-reporter/reporters/http.js
+++ b/modules/st2-action-reporter/reporters/http.js
@@ -19,6 +19,12 @@ function getCode(execution) {
       `${execution.result.traceback}`,
     ].join('\n');
   }
+  
+  if (execution.status === 'timeout') {
+    return [
+      `${execution.result.error}`,
+    ].join('\n');
+  }
 
   const result = [];
 


### PR DESCRIPTION
When http-request fails it only sends "error" in the result