### PR TITLE
Move inquiries api to /v1

### DIFF
--- a/apps/st2-inquiry/inquiry-details.component.js
+++ b/apps/st2-inquiry/inquiry-details.component.js
@@ -45,7 +45,6 @@ function getDeepestParentId(context) {
       handleResponse: (inquiry, response) => dispatch({
         type: 'RESPOND_INQUIRY',
         promise: api.request({
-          version: 'exp',
           method: 'put',
           path: `/inquiries/${inquiry.id}`,
         }, {


### PR DESCRIPTION
The inquiries API has been moved from `/exp` to `/v1` in https://github.com/StackStorm/st2/pull/4495

Change also needed here in Web UI. Note that default in st2-api module is to use v1 if not otherwise specified.