### PR TITLE
Add static to build settings

### DIFF
--- a/tasks/settings.json
+++ b/tasks/settings.json
@@ -17,6 +17,7 @@
       "index.html",
       "img/*",
       "font/*",
+      "static/*",
       "config.js",
       "favicon.ico"
     ],


### PR DESCRIPTION
`static/` is a common folder for adding static files to. In applications that
might rely on st2-build system it is good to include it here.