### PR TITLE
Save Button is not visible in Packs Config on Fireox

### DIFF
--- a/modules/st2-panel/style.css
+++ b/modules/st2-panel/style.css
@@ -754,8 +754,6 @@
 
     &-body {
       flex: 1;
-      display: table;
-
       border-spacing: 10px 0;
       width: 100%;
     }


### PR DESCRIPTION
The .st2-panel--detailed .st2-details class used by the Panels
packs-details component had display: table set though the contents
were not of type table. Removing the display:table fixed the issue