### PR TITLE
issue-710 fixed array of objects not validating

### DIFF
--- a/modules/st2-auto-form/fields/array.js
+++ b/modules/st2-auto-form/fields/array.js
@@ -17,9 +17,9 @@ const typeChecks = (type, value) => {
   const v = String(value);
   switch (type) {
     case 'number':
-      return !validator.isFloat(value) && `'${v}' is not a number`;
+      return !validator.isFloat(v) && `'${v}' is not a number`;
     case 'integer':
-      return !validator.isInt(value) && `'${v}' is not an integer`;
+      return !validator.isInt(v) && `'${v}' is not an integer`;
     case 'object':
       return !_.isPlainObject(value) && `'${v}' is not an object`;
     case 'string':
@@ -71,12 +71,16 @@ export default class ArrayField extends BaseTextField {
   }
 
   toStateValue(v) {
-    if (jsonCheck(v) || Array.isArray(v)) {
+    if (jsonCheck(v)) {
       return JSON.stringify(v);
     }
 
     if (isJinja(v)) {
       return v;
+    }
+
+    if (Array.isArray(v) && this.props.spec.items.type === 'object') {
+      return JSON.stringify(v);
     }
 
     const { secret } = this.props.spec || {};

--- a/modules/st2-auto-form/fields/array.js
+++ b/modules/st2-auto-form/fields/array.js
@@ -17,11 +17,11 @@ const typeChecks = (type, value) => {
   const v = String(value);
   switch (type) {
     case 'number':
-      return !validator.isFloat(v) && `'${v}' is not a number`;
+      return !validator.isFloat(value) && `'${v}' is not a number`;
     case 'integer':
-      return !validator.isInt(v) && `'${v}' is not an integer`;
+      return !validator.isInt(value) && `'${v}' is not an integer`;
     case 'object':
-      return !_.isPlainObject(v) && `'${v}' is not an object`;
+      return !_.isPlainObject(value) && `'${v}' is not an object`;
     case 'string':
     default:
       return false;
@@ -71,7 +71,7 @@ export default class ArrayField extends BaseTextField {
   }
 
   toStateValue(v) {
-    if (jsonCheck(v)) {
+    if (jsonCheck(v) || Array.isArray(v)) {
       return JSON.stringify(v);
     }
 


### PR DESCRIPTION
This PR deals with #710 where if a form has the datatype "array of objects" it would never validate it. It also deals with the string mutation of an array of objects, causing any entered array of objects to be mutated to [object Object]. 