### PR TITLE
Fix st2web to also work on http

### DIFF
--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -65,9 +65,9 @@ export class API {
     }
     else {
       this.server = {
-        api: `https://${window.location.host}/api`,
-        auth: `https://${window.location.host}/auth`,
-        stream: `https://${window.location.host}/stream`,
+        api: `${window.location.protocol}//${window.location.host}/api`,
+        auth: `${window.location.protocol}//${window.location.host}/auth`,
+        stream: `${window.location.protocol}//${window.location.host}/stream`,
         token: !_.isEmpty(token) ? token : null,
       };
     }

--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -65,9 +65,9 @@ export class API {
     }
     else {
       this.server = {
-        api: `${window.location.protocol}//${window.location.host}/api`,
-        auth: `${window.location.protocol}//${window.location.host}/auth`,
-        stream: `${window.location.protocol}//${window.location.host}/stream`,
+        api: `${window.location.protocol || 'https:'}//${window.location.host}/api`,
+        auth: `${window.location.protocol || 'https:'}//${window.location.host}/auth`,
+        stream: `${window.location.protocol || 'https:'}//${window.location.host}/stream`,
         token: !_.isEmpty(token) ? token : null,
       };
     }

--- a/modules/st2-api/tests/test-api.js
+++ b/modules/st2-api/tests/test-api.js
@@ -24,6 +24,27 @@ describe('API', () => {
     window.location.host = host; // restore initial value
   });
 
+  describe('can work with http', () => {
+    // capture initial value
+    const host = window.location.host;
+    const protocol = window.location.protocol;
+
+    // set test value
+    window.location.host = 'www.example.net:1234';
+    window.location.protocol = 'http:';
+
+    const api = new API();
+    api.connect();
+
+    expect(api.server.api).to.equal('http://www.example.net:1234/api');
+    expect(api.server.auth).to.equal('http://www.example.net:1234/auth');
+    expect(api.server.stream).to.equal('http://www.example.net:1234/stream');
+
+    // restore initial value
+    window.location.host = host;
+    window.location.protocol = protocol;
+  });
+
   describe('connect', () => {
     before(() => moxios.install());
     after(() => moxios.uninstall());


### PR DESCRIPTION
> We now expose http version of st2web in Kubernetes making it default and allowing users to configure HTTPs layer on top of it.  We found that st2web on http doesn't work, app is trying to redirect to https.

Don't redirect `HTTP` -> `HTTPS` on app level if user initially requested HTTP version. Try to preserve the original protocol instead.

Any redirects like that (when needed by security reasons) should be handled on server side.