### PR TITLE
Update Vagrantfile to Ubuntu Xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "public_network"
 
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 2048


### PR DESCRIPTION
Part of the removal of Ubuntu Trusty.

* [ ] Still need to update the `bootstrap.sh` script