### PR TITLE
Remove testing and deployment for Ubuntu Trusty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     machine: true
     environment:
       DEPLOY_PACKAGES: 1
-      DEB: trusty xenial bionic
+      DEB: xenial bionic
       RPM: el6 el7 el8
       ST2_HOST: localhost
       ST2_USERNAME: admin
@@ -40,7 +40,7 @@ jobs:
           name: Export package version
           command: |
             PKG_VERSION=$(node -e "console.log(require('./package.json').st2_version);")
-            PKG_RELEASE=$(packagecloud.sh next-revision trusty ${PKG_VERSION} st2web)
+            PKG_RELEASE=$(packagecloud.sh next-revision xenial ${PKG_VERSION} st2web)
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:
@@ -129,7 +129,6 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/artifacts
           paths:
-            - trusty
             - xenial
             - bionic
             - el6
@@ -140,7 +139,7 @@ jobs:
       - image: ruby:2.6.3
     environment:
       ARTIFACTS: /home/circleci/artifacts
-      DISTROS: trusty xenial bionic el6 el7 el8
+      DISTROS: xenial bionic el6 el7 el8
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
The `PKG_RELEASE` assignment is (I think) used to determine what the next release version string should be. As we deprecate OSes, we will need to update that to rely on a continuous stream. If I'm correct, it should not be set to an OS that we have not yet deployed on yet. I bumped it to use the Ubuntu Xenial packages, since those have a long rich release history.