### PR TITLE
Remove testing and deployment for Ubuntu Trusty (v3.2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     machine: true
     environment:
       DEPLOY_PACKAGES: 1
-      DEB: trusty xenial bionic
+      DEB: xenial bionic
       RPM: el6 el7 el8
       ST2_HOST: localhost
       ST2_USERNAME: admin
@@ -40,7 +40,7 @@ jobs:
           name: Export package version
           command: |
             PKG_VERSION=$(node -e "console.log(require('./package.json').st2_version);")
-            PKG_RELEASE=$(packagecloud.sh next-revision trusty ${PKG_VERSION} st2web)
+            PKG_RELEASE=$(packagecloud.sh next-revision xenial ${PKG_VERSION} st2web)
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:
@@ -129,7 +129,6 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/artifacts
           paths:
-            - trusty
             - xenial
             - bionic
             - el6
@@ -140,7 +139,7 @@ jobs:
       - image: ruby:2.6.3
     environment:
       ARTIFACTS: /home/circleci/artifacts
-      DISTROS: trusty xenial bionic el6 el7 el8
+      DISTROS: xenial bionic el6 el7 el8
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Cherry pick from #748. Don't try to deploy Ubuntu Trusty packages.