### PR TITLE
Do not lookup release from package cloud if fork in circle config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,11 @@ jobs:
           name: Export package version
           command: |
             PKG_VERSION=$(node -e "console.log(require('./package.json').st2_version);")
-            PKG_RELEASE=$(packagecloud.sh next-revision xenial ${PKG_VERSION} st2web)
+            if [ -n "$PACKAGECLOUD_TOKEN" ]; then
+              PKG_RELEASE=$(packagecloud.sh next-revision xenial ${PKG_VERSION} st2web)
+            else
+              PKG_RELEASE=1
+            fi
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
             if [ -n "$PACKAGECLOUD_TOKEN" ]; then
               PKG_RELEASE=$(packagecloud.sh next-revision xenial ${PKG_VERSION} st2web)
             else
+              # is fork
               PKG_RELEASE=1
             fi
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV


### PR DESCRIPTION
if package cloud token is not set use hard coded value of 1
fixes #752 

PR from forks are not able to be run through unit testing.  This is because the package cloud token is not set.  Here we are not going to lookup the release number in package cloud if it is a fork.  
This was stolen from https://github.com/StackStorm/st2-packages/blob/29a493e33de928e6df452a9102e80aaeadc5ec53/.circle/buildenv_st2.sh#L45-L51