### PR TITLE
Stackstorm update gulp-csscomb

### DIFF
--- a/apps/st2-actions/package.json
+++ b/apps/st2-actions/package.json
@@ -67,7 +67,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-code/package.json
+++ b/apps/st2-code/package.json
@@ -53,7 +53,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-history/package.json
+++ b/apps/st2-history/package.json
@@ -69,7 +69,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-inquiry/package.json
+++ b/apps/st2-inquiry/package.json
@@ -71,7 +71,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-packs/package.json
+++ b/apps/st2-packs/package.json
@@ -61,7 +61,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-rules/package.json
+++ b/apps/st2-rules/package.json
@@ -66,7 +66,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/apps/st2-triggers/package.json
+++ b/apps/st2-triggers/package.json
@@ -66,7 +66,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-action-reporter/package.json
+++ b/modules/st2-action-reporter/package.json
@@ -61,7 +61,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-api/package.json
+++ b/modules/st2-api/package.json
@@ -27,12 +27,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@hapi/cryptiles": "^4.2.1",
     "atob": "^2.1",
     "axios": "0.18.0",
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-auto-form/package.json
+++ b/modules/st2-auto-form/package.json
@@ -51,13 +51,13 @@
     "access": "public"
   },
   "dependencies": {
+    "@hapi/cryptiles": "^4.2.1",
     "@stackstorm/module-value-format": "^2.4.3",
     "@stackstorm/st2-style": "^2.4.3",
     "atob": "^2.1",
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-criteria/package.json
+++ b/modules/st2-criteria/package.json
@@ -59,7 +59,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-filter-expandable/package.json
+++ b/modules/st2-filter-expandable/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-filter/package.json
+++ b/modules/st2-filter/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-flex-table/package.json
+++ b/modules/st2-flex-table/package.json
@@ -82,7 +82,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-flow-link/package.json
+++ b/modules/st2-flow-link/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-forms/package.json
+++ b/modules/st2-forms/package.json
@@ -82,7 +82,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-highlight/package.json
+++ b/modules/st2-highlight/package.json
@@ -71,7 +71,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-label/package.json
+++ b/modules/st2-label/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-login/package.json
+++ b/modules/st2-login/package.json
@@ -59,7 +59,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-menu/package.json
+++ b/modules/st2-menu/package.json
@@ -59,7 +59,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-notification/package.json
+++ b/modules/st2-notification/package.json
@@ -44,7 +44,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-pack-icon/package.json
+++ b/modules/st2-pack-icon/package.json
@@ -60,7 +60,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-panel/package.json
+++ b/modules/st2-panel/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-popup/package.json
+++ b/modules/st2-popup/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-portion-bar/package.json
+++ b/modules/st2-portion-bar/package.json
@@ -53,12 +53,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@hapi/cryptiles": "^4.2.1",
     "@stackstorm/st2-style": "^2.4.3",
     "atob": "^2.1",
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-proportional/package.json
+++ b/modules/st2-proportional/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-remote-form/package.json
+++ b/modules/st2-remote-form/package.json
@@ -57,7 +57,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-router/package.json
+++ b/modules/st2-router/package.json
@@ -31,7 +31,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-scroll-into-view/package.json
+++ b/modules/st2-scroll-into-view/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-select-on-click/package.json
+++ b/modules/st2-select-on-click/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-store/package.json
+++ b/modules/st2-store/package.json
@@ -32,7 +32,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-style/package.json
+++ b/modules/st2-style/package.json
@@ -46,7 +46,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-test-utils/package.json
+++ b/modules/st2-test-utils/package.json
@@ -31,7 +31,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-time/package.json
+++ b/modules/st2-time/package.json
@@ -31,7 +31,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-title/package.json
+++ b/modules/st2-title/package.json
@@ -38,7 +38,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-value-format/package.json
+++ b/modules/st2-value-format/package.json
@@ -34,7 +34,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/modules/st2-view/package.json
+++ b/modules/st2-view/package.json
@@ -58,7 +58,7 @@
     "babel-eslint": "10.0.1",
     "babelify": "10.0.0",
     "cached-path-relative": "^1.0.2",
-    "cryptiles": "^4",
+    "@hapi/cryptiles": "^4.2.1",
     "deep-extend": "^0.6.0",
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "."
   ],
   "dependencies": {
+    "@hapi/cryptiles": "^4.2.1",
     "@stackstorm/app-actions": "^2.4.3",
     "@stackstorm/app-code": "^2.4.3",
     "@stackstorm/app-history": "^2.4.3",
@@ -68,7 +69,6 @@
     "atob": "2.1.2",
     "cached-path-relative": "1.0.2",
     "classnames": "2.2.6",
-    "cryptiles": "4.1.3",
     "deep-extend": "0.6.0",
     "growl": "1.10.5",
     "insert-css": "2.0.0",

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -39,7 +39,7 @@
     "growl": "1.10.5",
     "gulp": "4.0.1",
     "gulp-concat": "2.6.1",
-    "gulp-csscomb": "3.0.8",
+    "gulp-csscomb": "3.1.0",
     "gulp-env": "0.4.0",
     "gulp-eslint": "5.0.0",
     "gulp-header": "2.0.7",

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -28,7 +28,7 @@
     "babelify": "10.0.0",
     "cached-path-relative": "1.0.2",
     "chalk": "2.4.2",
-    "cryptiles": "4.1.3",
+    "@hapi/cryptiles": "^4.2.1",
     "css-extract": "1.3.0",
     "deep-extend": "0.6.0",
     "event-stream": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,25 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
+"@hapi/boom@7.x.x":
+  version "7.4.11"
+  resolved "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz#37af8417eb9416aef3367aa60fa04a1a9f1fc262"
+  integrity sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==
+  dependencies:
+    "@hapi/hoek" "8.x.x"
+
+"@hapi/cryptiles@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz#ff0f18d79074659838caedbb911851313ad1ffbc"
+  integrity sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==
+  dependencies:
+    "@hapi/boom" "7.x.x"
+
+"@hapi/hoek@8.x.x":
+  version "8.5.1"
+  resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
+  integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
+
 "@lerna/add@3.13.1":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
@@ -3149,7 +3168,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cryptiles@4.1.3, cryptiles@^4:
+cryptiles@4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-4.1.3.tgz#2461d3390ea0b82c643a6ba79f0ed491b0934c25"
   integrity sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5054,13 +5054,15 @@ gulp-concat@2.6.1:
     through2 "^2.0.0"
     vinyl "^2.0.0"
 
-gulp-csscomb@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/gulp-csscomb/-/gulp-csscomb-3.0.8.tgz#df34824a580a4c7d3351c1e8ebb6ad7a1d5a89b7"
-  integrity sha1-3zSCSlgKTH0zUcHo67ateh1aibc=
+gulp-csscomb@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/gulp-csscomb/-/gulp-csscomb-3.1.0.tgz#bab3e66ef71b087932e4ccead2a01883403545ad"
+  integrity sha512-DNg9GcnN1hHYCVP5nO+pKNL9BPW9ucD6DmyS36etPpLc4mMNPd+xjM8bf9o+wZdNZJok9a/Wxv3/PAQwlFAl4A==
   dependencies:
+    ansi-colors "^1.0.1"
     csscomb "^3.1.7"
-    gulp-util "^3.0.7"
+    fancy-log "^1.3.2"
+    plugin-error "^0.1.2"
     through2 "^2.0.1"
 
 gulp-env@0.4.0:
@@ -5172,7 +5174,7 @@ gulp-uglify-es@1.0.4:
     vinyl "^2.1.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
-gulp-util@3.0.8, gulp-util@^3.0.7:
+gulp-util@3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,13 +2207,6 @@ body-parser@~1.8.0:
     raw-body "1.3.0"
     type-is "~1.5.1"
 
-boom@7.x.x:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-7.3.0.tgz#733a6d956d33b0b1999da3fe6c12996950d017b9"
-  integrity sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==
-  dependencies:
-    hoek "6.x.x"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3167,13 +3160,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-4.1.3.tgz#2461d3390ea0b82c643a6ba79f0ed491b0934c25"
-  integrity sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==
-  dependencies:
-    boom "7.x.x"
 
 crypto-browserify@^3.0.0:
   version "3.12.0"
@@ -5416,11 +5402,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoek@6.x.x:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
-  integrity sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==
 
 hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
updated gulp-csscomb in order to fix deprecated minimatch