### PR TITLE
Remove EL6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     environment:
       DEPLOY_PACKAGES: 1
       DEB: xenial bionic
-      RPM: el6 el7 el8
+      RPM: el7 el8
       ST2_HOST: localhost
       ST2_USERNAME: admin
       ST2_PASSWORD: 123
@@ -136,7 +136,6 @@ jobs:
           paths:
             - xenial
             - bionic
-            - el6
             - el7
             - el8
   deploy:
@@ -144,7 +143,7 @@ jobs:
       - image: ruby:2.6.3
     environment:
       ARTIFACTS: /home/circleci/artifacts
-      DISTROS: xenial bionic el6 el7 el8
+      DISTROS: xenial bionic el7 el8
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
RHEL 6/CentOS 6 support is being deprecated. Remove el6 from circleci builds.