### PR TITLE
Updated lodash 4.17.12 to 4.17.19

### DIFF
--- a/apps/st2-actions/package.json
+++ b/apps/st2-actions/package.json
@@ -63,7 +63,7 @@
     "@stackstorm/module-time": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
     "@stackstorm/module-view": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/apps/st2-code/package.json
+++ b/apps/st2-code/package.json
@@ -52,7 +52,7 @@
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-flex-table": "^2.4.3",
     "@stackstorm/module-api": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-redux": "7.0.2",

--- a/apps/st2-history/package.json
+++ b/apps/st2-history/package.json
@@ -65,7 +65,7 @@
     "@stackstorm/module-time": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
     "@stackstorm/module-view": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/apps/st2-inquiry/package.json
+++ b/apps/st2-inquiry/package.json
@@ -58,7 +58,7 @@
     "@stackstorm/module-router": "^2.4.3",
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/apps/st2-packs/package.json
+++ b/apps/st2-packs/package.json
@@ -57,7 +57,7 @@
     "@stackstorm/module-router": "^2.4.3",
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/apps/st2-rules/package.json
+++ b/apps/st2-rules/package.json
@@ -62,7 +62,7 @@
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-time": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/apps/st2-triggers/package.json
+++ b/apps/st2-triggers/package.json
@@ -58,7 +58,7 @@
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-time": "^2.4.3",
     "@stackstorm/module-title": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-api/package.json
+++ b/modules/st2-api/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "axios": "^0.18.0",

--- a/modules/st2-auto-form/package.json
+++ b/modules/st2-auto-form/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@stackstorm/module-value-format": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-criteria/package.json
+++ b/modules/st2-criteria/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@stackstorm/module-auto-form": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-filter-expandable/package.json
+++ b/modules/st2-filter-expandable/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "4.17.12"
+    "lodash": "4.17.19"
   },
   "devDependencies": {
     "@stackstorm/st2-style": "2.4.3",

--- a/modules/st2-flex-table/package.json
+++ b/modules/st2-flex-table/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@stackstorm/module-store": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-forms/package.json
+++ b/modules/st2-forms/package.json
@@ -77,7 +77,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-menu/package.json
+++ b/modules/st2-menu/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@stackstorm/module-api": "^2.4.3",
     "@stackstorm/module-router": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6"

--- a/modules/st2-portion-bar/package.json
+++ b/modules/st2-portion-bar/package.json
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/modules/st2-proportional/package.json
+++ b/modules/st2-proportional/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/modules/st2-router/package.json
+++ b/modules/st2-router/package.json
@@ -31,7 +31,7 @@
     "@stackstorm/module-store": "^2.4.3",
     "@stackstorm/module-api": "^2.4.3",
     "@stackstorm/module-login": "^2.4.3",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@stackstorm/module-store": "^2.4.3",
     "moment": "2.24.0",
     "urijs": "1.19.1",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-redux": "7.0.2",

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -60,7 +60,7 @@
     "gulp-uglify-es": "1.0.4",
     "gulp-util": "3.0.8",
     "gulp-webserver": "0.9.1",
-    "lodash": "4.17.12",
+    "lodash": "4.17.19",
     "mocha": "6.1.4",
     "pathmodify": "0.5.0",
     "require-dir": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5342,10 +5342,10 @@ lodash.values@~2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@4.17.12:
-  version "4.17.12"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.12.tgz#a712c74fdc31f7ecb20fe44f157d802d208097ef"
-  integrity sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA==
+lodash@4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lodash@>=2.4.0, lodash@^4.17.11:
   version "4.17.11"


### PR DESCRIPTION
yarn audit --no-color --groups dependencies
yarn audit v1.22.4                                                                                                                                                                                       
0 vulnerabilities found - Packages audited: 120                                                                                                                                                          
✨  Done in 1.78s.