### PR TITLE
Removed node_modules folder from app/st2-workflows while build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ build-dev:
 
 build-and-install:
 	make build
-    make install
+	make install
 
 build:
 	echo "build-and-install"
-	
+
 	make npm-install
 
 	make lerna

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,8 @@ build-and-install:
 
 build:
 	echo "build-and-install"
-
 	make npm-install
-
 	make lerna
-
 	echo "run gulp production directly"
 	npm run build
 
@@ -45,7 +42,6 @@ install:
 	echo "make install"
 	echo "mkdir -p $(DESTDIR)$(PREFIX)"
 	mkdir -p $(DESTDIR)$(PREFIX)
-
 	echo "cp -R $(CURDIR)/build/* $(DESTDIR)$(PREFIX)"
 	cp -R $(CURDIR)/build/* $(DESTDIR)$(PREFIX)
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ npm-install:
 lerna:
 	echo "lerna"
 	lerna bootstrap
+	rm -rf apps/st2-workflows/node_modules
 
 build-dev:
 	echo "build-dev"
@@ -24,12 +25,11 @@ build-dev:
 
 build-and-install:
 	make build
-
-	make install
+    make install
 
 build:
 	echo "build-and-install"
-
+	
 	make npm-install
 
 	make lerna


### PR DESCRIPTION
Remove the node_modules from app/st2-workflows that is auto-generated by learn. This causes conflict which result in st2flow UI coming out as blank screen.