### PR TITLE
workflow coordinates changes auto save and workflow header changes

### DIFF
--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -30,7 +30,8 @@ import AutoForm from '@stackstorm/module-auto-form';
 import Button from '@stackstorm/module-forms/button.component';
 import { Route } from '@stackstorm/module-router';
 import globalStore from '@stackstorm/module-store';
-
+import Header from '@stackstorm/st2flow-header';
+import CollapseButton from '@stackstorm/st2flow-canvas/collapse-button';
 import store from './store';
 import style from './style.css';
 
@@ -57,6 +58,10 @@ const POLL_INTERVAL = 5000;
     //   type: 'PANEL_TOGGLE_COLLAPSE',
     //   name,
     // }),
+    toggleCollapse: name => dispatch({
+      type: 'PANEL_TOGGLE_COLLAPSE',
+      name,
+    }),
     fetchActions: () => dispatch({
       type: 'FETCH_ACTIONS',
       promise: api.request({ path: '/actions/views/overview' })
@@ -89,7 +94,7 @@ export default class Workflows extends Component {
    layout: PropTypes.func,
    sendSuccess: PropTypes.func,
    sendError: PropTypes.func,
-
+   toggleCollapse: PropTypes.func,
    routes: PropTypes.arrayOf(PropTypes.shape({
      title: PropTypes.string.isRequired,
      href: PropTypes.string,
@@ -105,7 +110,6 @@ export default class Workflows extends Component {
  };
 
  async componentDidMount() {
-
    this.props.fetchActions();
  }
 
@@ -289,7 +293,6 @@ export default class Workflows extends Component {
      type: 'SAVE_WORKFLOW',
      promise,
    });
-
    return promise;
  }
 
@@ -303,16 +306,16 @@ export default class Workflows extends Component {
 
   render() {
     // const { isCollapsed = {}, toggleCollapse, actions, undo, redo, layout, meta, input, dirty } = this.props;
-    const { isCollapsed = {}, actions, undo, redo, layout, meta, input, dirty } = this.props;
+    const { isCollapsed = {}, actions, toggleCollapse,undo, redo, layout, meta, input, dirty } = this.props;
     const { runningWorkflow, showForm } = this.state;
-    
+   
     const autoFormData = input && input.reduce((acc, value) => {
       if(typeof value === 'object') {
         acc = { ...acc, ...value };
       }
       return acc;
     }, {});
-    // console.log("autoFormData*******",autoFormData);
+   
     return (
       <Route
         path='/action/:ref?/:section?'
@@ -320,7 +323,11 @@ export default class Workflows extends Component {
           return (
             <Provider store={globalStore}>
               <div className="component">
-                <Menu location={location} routes={this.props.routes} />
+                <div className="component-row-header">
+                  { !isCollapsed.header && <Header className="header" /> }
+                  <CollapseButton position="top" state={isCollapsed.header} onClick={() => toggleCollapse('header')} />
+                </div> 
+                {/* <Menu location={location} routes={this.props.routes} /> */}
                 <div className="component-row-content">
                   { !isCollapsed.palette && <Palette className="palette" actions={actions} /> }
                   <HotKeys

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -47,7 +47,7 @@ import PoissonRectangleSampler from './poisson-rect';
 import { origin } from './const';
 
 import style from './style.css';
-
+import store from '../../apps/st2-workflows/store';
 type DOMMatrix = {
   m11: number,
   m22: number
@@ -212,37 +212,18 @@ function constructPathOrdering(
     }),
   })
 )
-export default class Canvas extends Component<{
-  children: Node,
-      className?: string,
-
-  navigation: Object,
-  navigate: Function,
-
-  tasks: Array<TaskInterface>,
-  transitions: Array<Object>,
-  notifications: Array<NotificationInterface>,
-  issueModelCommand: Function,
-  nextTask: string,
-
-  isCollapsed: Object,
-  toggleCollapse: Function,
-}, {
-      scale: number,
-}> {
+export default class Canvas extends Component {
+ 
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-
     navigation: PropTypes.object,
     navigate: PropTypes.func,
-
     tasks: PropTypes.array,
     transitions: PropTypes.array,
     notifications: PropTypes.array,
     issueModelCommand: PropTypes.func,
     nextTask: PropTypes.string,
-
     isCollapsed: PropTypes.object,
     toggleCollapse: PropTypes.func,
   }
@@ -592,6 +573,10 @@ export default class Canvas extends Component<{
 
   handleTaskMove = (task: TaskRefInterface, coords: CanvasPoint) => {
     this.props.issueModelCommand('updateTask', task, { coords });
+    store.dispatch({
+      type: 'SAVE_WORKFLOW',
+      status:'success',
+    });
   }
 
   handleTaskSelect = (task: TaskRefInterface) => {

--- a/modules/st2flow-header/index.js
+++ b/modules/st2flow-header/index.js
@@ -58,7 +58,9 @@ export default class Header extends Component<{
 
     return (
       <div className={cx(this.props.className, this.style.component)}>
-        <div className={this.style.logo}><img src="static/logo-extreme.svg" width="101" height="25" /></div>
+        <div className={this.style.logo}>
+          <img src="../../img/logo.svg" width="101" height="25" /> 
+        </div>
         <div className={this.style.subtitle}>Workflow Designer</div>
         <div className={this.style.separator} />
         {

--- a/modules/st2flow-header/style.css
+++ b/modules/st2flow-header/style.css
@@ -21,8 +21,8 @@ limitations under the License.
   display: flex;
   align-items: center;
 
-  background: linear-gradient(90deg, #400099 0%, #a51890 100%);
-  color: white;
+  background:white;
+  color:#4B4A4F;
 
   /* For collapse button */
   padding-right: 40px;


### PR DESCRIPTION
Fixes for below issues.
1))Open an existing workflow in st2flow UI (say any examples.orquesta-*), the first time we open the workflow, the st2flow UI always expect  to save the workflow before it's execution . If we didn't make any changes to the workflow, the st2flow UI shouldn't prompt me to save it- Added auto save, when there only coordinates change.
2)Done changes to header part in workflow tab.