### PR TITLE
Inquiry line break changes

### DIFF
--- a/modules/st2-auto-form/style.css
+++ b/modules/st2-auto-form/style.css
@@ -292,7 +292,7 @@
 
   &__description {
     margin-top: -5px;
-
+    white-space: pre-wrap;
     opacity: .7;
     color: var(--grey-darken-1);
   }


### PR DESCRIPTION
In the inquiry page of web UI, if the description of the inquiry input is multiple lines, the web UI does not show the line breaks correctly and will just display multiline text as a single line. This patch fixes the issue will display multi line text with proper line breaks.

Fixes issue https://github.com/StackStorm/st2web/issues/739