### PR TITLE
entry-point-auto-populate-and-yaml-validation

### DIFF
--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -30,8 +30,6 @@ import AutoForm from '@stackstorm/module-auto-form';
 import Button from '@stackstorm/module-forms/button.component';
 import { Route } from '@stackstorm/module-router';
 import globalStore from '@stackstorm/module-store';
-import Header from '@stackstorm/st2flow-header';
-import CollapseButton from '@stackstorm/st2flow-canvas/collapse-button';
 import store from './store';
 import style from './style.css';
 
@@ -54,14 +52,6 @@ const POLL_INTERVAL = 5000;
     panels, actions, meta, metaSource, workflowSource, pack, input, dirty,
   } }) => ({ isCollapsed: panels, actions, meta, metaSource, workflowSource, pack, input, dirty }),
   (dispatch) => ({
-    // toggleCollapse: name => dispatch({
-    //   type: 'PANEL_TOGGLE_COLLAPSE',
-    //   name,
-    // }),
-    toggleCollapse: name => dispatch({
-      type: 'PANEL_TOGGLE_COLLAPSE',
-      name,
-    }),
     fetchActions: () => dispatch({
       type: 'FETCH_ACTIONS',
       promise: api.request({ path: '/actions/views/overview' })
@@ -94,7 +84,6 @@ export default class Workflows extends Component {
    layout: PropTypes.func,
    sendSuccess: PropTypes.func,
    sendError: PropTypes.func,
-   toggleCollapse: PropTypes.func,
    routes: PropTypes.arrayOf(PropTypes.shape({
      title: PropTypes.string.isRequired,
      href: PropTypes.string,
@@ -114,6 +103,7 @@ export default class Workflows extends Component {
  }
 
  handleFormChange(data) {
+   
    if(!data) {
      data = {};
    }
@@ -253,19 +243,15 @@ export default class Workflows extends Component {
 
  save() {
    const { pack, meta, actions, workflowSource, metaSource, setMeta } = this.props;
-
    const existingAction = actions.find(e => e.name === meta.name && e.pack === pack);
 
    if (!meta.name) {
      throw { response: { data: { faultstring: 'You must provide a name of the workflow.'}}};
    }
-
-   if (typeof meta.entry_point === 'undefined' && typeof meta.name !== 'undefined') {
-     const entryPoint = `workflows/${meta.name}.yaml`;
-     meta.entry_point = entryPoint;
-     setMeta('entry_point', entryPoint);
+   
+   if (!meta.entry_point) {
+     throw { response: { data: { faultstring: 'You must provide a entry point of the workflow.'}}};
    }
-
 
    meta.pack = pack;
    meta.metadata_file = existingAction && existingAction.metadata_file && existingAction.metadata_file || `actions/${meta.name}.meta.yaml`;
@@ -306,7 +292,7 @@ export default class Workflows extends Component {
 
   render() {
     // const { isCollapsed = {}, toggleCollapse, actions, undo, redo, layout, meta, input, dirty } = this.props;
-    const { isCollapsed = {}, actions, toggleCollapse,undo, redo, layout, meta, input, dirty } = this.props;
+    const { isCollapsed = {}, actions, undo, redo, layout, meta, input, dirty } = this.props;
     const { runningWorkflow, showForm } = this.state;
    
     const autoFormData = input && input.reduce((acc, value) => {

--- a/modules/st2-menu/menu.component.js
+++ b/modules/st2-menu/menu.component.js
@@ -88,41 +88,41 @@ export default class Menu extends React.Component {
 
         <div className={style.spacer} />
 
-     { (this.props.location.pathname).match('^/action') !== null && (this.props.location.pathname).match('^/actions') == null ? "" :
-        <div className={style.nav}>
-          { _.map(routes, ({ title, href, url, target, icon }) => {
-            if (href) {
-              return (
-                <a
-                  key={title}
-                  className={style.navItem}
-                  href={href}
-                  target={target}
-                >
-                  <Icon name={icon} style={style} />
-                  { title }
-                </a>
-              );
-            }
+        { (this.props.location.pathname).match('^/action') !== null && (this.props.location.pathname).match('^/actions') == null ? '' : (
+          <div className={style.nav}>
+            { _.map(routes, ({ title, href, url, target, icon }) => {
+              if (href) {
+                return (
+                  <a
+                    key={title}
+                    className={style.navItem}
+                    href={href}
+                    target={target}
+                  >
+                    <Icon name={icon} style={style} />
+                    { title }
+                  </a>
+                );
+              }
 
-            if (url) {
-              return (
-                <Link
-                  key={title}
-                  className={cx(style.navItem, location.pathname.indexOf(url) === 0 && style.navItemActive)}
-                  to={url}
-                  target={target}
-                >
-                  <Icon name={icon} style={style} />
-                  { title }
-                </Link>
-              );
-            }
+              if (url) {
+                return (
+                  <Link
+                    key={title}
+                    className={cx(style.navItem, location.pathname.indexOf(url) === 0 && style.navItemActive)}
+                    to={url}
+                    target={target}
+                  >
+                    <Icon name={icon} style={style} />
+                    { title }
+                  </Link>
+                );
+              }
 
-            return null;
-          }) }
-        </div>
-     }
+              return null;
+            }) }
+          </div>
+        )}
         <div className={style.spacer} />
 
         <div className={style.side}>

--- a/modules/st2-pack-icon/pack-icon.component.js
+++ b/modules/st2-pack-icon/pack-icon.component.js
@@ -72,14 +72,14 @@ export default class PackIcon extends React.Component {
 
     if (naked) {
       if (icons[name]) {
-         return (
+        return (
           <img className={cx(style.image, small && style.imageSmall)} src={icons[name]} />
         );
       }
       else{
         return(
-          <img src="img/icon.png" width="32" height="32"/>
-        )
+          <img src="img/icon.png" width="32" height="32" />
+        );
       }
       return (
         <img className={cx(style.image, small && style.imageSmall)} src={icons[name]} />

--- a/modules/st2flow-model/base-class.js
+++ b/modules/st2flow-model/base-class.js
@@ -21,7 +21,7 @@ import { diff } from 'deep-diff';
 import EventEmitter from './event-emitter';
 
 import { TokenSet, crawler, util } from '@stackstorm/st2flow-yaml';
-
+import notification from '@stackstorm/module-notification';
 const ajv = new Ajv();
 const STR_ERROR_YAML = 'yaml-error';
 const STR_ERROR_SCHEMA = 'schema-error';
@@ -66,7 +66,6 @@ class BaseClass {
       // The parser is overly verbose on certain errors, so
       // just grab the relevant parts. Also normalize it to an array.
       const exception = Array.isArray(ex) ? (ex.length > 2 ? ex.slice(0, 2) : ex) : [ ex ];
-
       // Ensure every mark uses "row" instead of "line".
       // Replace "JS-YAML" with something more friendly.
       exception.forEach(err => {
@@ -75,12 +74,15 @@ class BaseClass {
         }
 
         err.message = err.message.replace('JS-YAML:', 'YAML Parser:');
+        notification.error(err.message);
+       
       });
 
       this.yaml = yaml;
+      
       this.emitError(exception, STR_ERROR_YAML);
-
-      return;
+       return;
+     
     }
 
     this.emitChange(oldTree);
@@ -141,6 +143,7 @@ class BaseClass {
 
   emitChange(oldTree: Object): void {
     const newTree = this.tokenSet.toObject();
+  
     this.errors = [];
 
     this.validate();


### PR DESCRIPTION
1)In workflow tab,previously entry_point was auto populate on **save**, now this fix is for entry_point will auto populate as user types the name of workflow 
2)If there is some syntax error in an existing workflow YAML, when we try to edit that in the st2flow UI, the flow UI return a blank canvas but doesn't tell user what happened - this fix will show syntax error message to the user.
