### PR TITLE
opening history link in the existing parent window

### DIFF
--- a/apps/st2-actions/actions-details.component.js
+++ b/apps/st2-actions/actions-details.component.js
@@ -212,7 +212,9 @@ export default class ActionsDetails extends React.Component {
       },
     });
   }
-
+setWindowName(e){
+   window.name="parent"
+}
   handleRun(e, ...args) {
     e.preventDefault();
 
@@ -256,6 +258,7 @@ export default class ActionsDetails extends React.Component {
                   target="_blank"
                   to={`/action/${action.ref}`}
                   className="st2-forms__button st2-details__toolbar-button"
+                  onClick ={e => this.setWindowName(e)}
                 >
                   Edit
                 </Link>

--- a/modules/st2flow-notifications/index.js
+++ b/modules/st2flow-notifications/index.js
@@ -44,10 +44,10 @@ class Notification extends Component {
 
   style = style
 
-  redirectLinkToParent = (newlink) => {
-    opener.location.href = newlink;
-    close();
-  
+  redirectLinkToParent = (e,newlink) => {
+     e.preventDefault();
+     var goBack = window.open(newlink, 'parent');
+     goBack.focus();
   }
 
   render() {
@@ -61,9 +61,10 @@ class Notification extends Component {
         </button>
         { notification.message }
         { notification.link && (
-          <a href={notification.link} onClick={e => this.redirectLinkToParent(notification.link)}>
+          <a href={notification.link} onClick={e => this.redirectLinkToParent(e,notification.link)}>
             {notification.link}
           </a>
+          
         ) }
       </div>
     );


### PR DESCRIPTION
1)After executing the workflow, a link to the execution in history tab is displayed in a pop up box.  If user click on this link, the current window will go to the history tab in the main UI. This PR will resolve this issue. When user click on this link the current window will remain same and history tab will get focused in existing parent window.