### PR TITLE
Fix join all tasks radio button visibility

### DIFF
--- a/modules/st2flow-details/style.css
+++ b/modules/st2flow-details/style.css
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+@import "@stackstorm/st2-style/colors.css";
 :root {
   --token-color: #eee;
   --yellow-lighten-5: #fff5e9;
   --yellow-base: #FF9E1B;
-}
+ }
 
 .component {
   display: flex;


### PR DESCRIPTION
Fix issue where the join all tasks radio button in st2flow task attributes panel is not visible.