### PR TITLE
chaging parameter name causing for duplication of parameter issue fixes

### DIFF
--- a/modules/st2flow-details/parameters-panel.js
+++ b/modules/st2flow-details/parameters-panel.js
@@ -82,7 +82,7 @@ export default class Parameters extends Component<{
   handleChange(oldName: string, { name, ...properties }: { name: string }) {
     const { ...parameters } = this.props.meta.parameters;
     if (oldName !== name) {
-      delete parameters[name];
+      delete parameters[oldName];
     }
     this.props.setMeta('parameters', sortParameters({ ...parameters, [name]: properties}));
     this.setState({ edit: false });


### PR DESCRIPTION
1) Changing parameter name on GUI causes parameter duplication instead of update- This PR will resolve this issue, it will update parameter name only, without creating duplication