### PR TITLE
Use st2-docker master docker compose setup for end to end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: Reset test containers
           command: |
-            docker-compose -f ~/st2-docker/docker-compose.yml down -v --rmi
+            docker-compose -f ~/st2-docker/docker-compose.yml down --rmi
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
             sleep 100
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,16 +75,17 @@ jobs:
       - run:
           name: Clone test containers
           command: |
-            # Use DEPRECATED/all-in-one for now, we'll have to circle back around
-            # and fix this to use the master branch
             echo "Cloning ${ST2_DOCKER_BRANCH:-master} branch of st2-docker"
             git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
       - run:
-          name: Start test containers
+          name: Configufe docker compsoe config
           command: |
+            # Configure allow origin in the user config
             echo "[api]" > ~/st2-docker/files/st2.user.conf
             echo "allow_origin = *" >> ~/st2-docker/files/st2.user.conf
-
+      - run:
+          name: Start test containers
+          command: |
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
             sleep 60
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Start test containers
           command: |
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
-            sleep 60
+            sleep 100
       - run:
           name: Check test containers
           command: |
@@ -100,7 +100,7 @@ jobs:
           command: |
             docker-compose -f ~/st2-docker/docker-compose.yml down -v --rmi
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
-            sleep 60
+            sleep 100
       - run:
           name: Recheck test containers
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ jobs:
           command: |
             docker-compose -f ~/st2-docker/docker-compose.yml exec st2client st2 run core.noop
             docker-compose -f ~/st2-docker/docker-compose.yml exec st2client st2 execution list
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 execution list
       - run:
           name: Run tests on production version
           command: npm run test-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,11 @@ jobs:
       DEPLOY_PACKAGES: 1
       DEB: xenial bionic
       RPM: el7 el8
+      ST2_VERSION: "3.5dev"
       ST2_HOST: localhost
-      ST2_USERNAME: admin
-      ST2_PASSWORD: 123
+      ST2_PROTOCOL: http
+      ST2_USERNAME: st2admin
+      ST2_PASSWORD: Ch@ngeMe
       ST2_TEST_ENVIRONMENT: https://github.com/StackStorm/st2-docker
     steps:
       - checkout
@@ -75,46 +77,34 @@ jobs:
           command: |
             # Use DEPRECATED/all-in-one for now, we'll have to circle back around
             # and fix this to use the master branch
-            echo "Cloning ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} branch of st2-docker"
-            git clone --branch ${ST2_DOCKER_BRANCH:-DEPRECATED/all-in-one} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
-      - run:
-          name: Update env variables for test containers
-          command: |
-            make -C ~/st2-docker env
-            echo -e "ST2_USER=${ST2_USERNAME}\nST2_PASSWORD=${ST2_PASSWORD}" > ~/st2-docker/conf/stackstorm.env
-            cat ~/st2-docker/conf/stackstorm.env
+            echo "Cloning ${ST2_DOCKER_BRANCH:-master} branch of st2-docker"
+            git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
       - run:
           name: Start test containers
-          environment:
-            ST2_IMAGE_TAG: "latest"
           command: |
+            echo "[api]" > ~/st2-docker/files/st2.user.conf
+            echo "allow_origin = *" >> ~/st2-docker/files/st2.user.conf
+
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
             sleep 60
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm crudini --set /etc/st2/st2.conf api allow_origin "*"
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl restart
       - run:
           name: Check test containers
           command: |
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 run core.noop
+            docker-compose -f ~/st2-docker/docker-compose.yml exec st2client st2 run core.noop
       - run:
           name: Run functional tests
           command: npm run test-functional
       - run:
           name: Reset test containers
-          environment:
-            ST2_IMAGE_TAG: "latest"
           command: |
-            docker-compose -f ~/st2-docker/docker-compose.yml down
+            docker-compose -f ~/st2-docker/docker-compose.yml down -v --rmi
             docker-compose -f ~/st2-docker/docker-compose.yml up -d
             sleep 60
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm crudini --set /etc/st2/st2.conf api allow_origin "*"
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2ctl restart
       - run:
           name: Recheck test containers
-          environment:
-            ST2_IMAGE_TAG: "latest"
           command: |
-            docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 run core.noop
+            docker-compose -f ~/st2-docker/docker-compose.yml exec st2client st2 run core.noop
+            docker-compose -f ~/st2-docker/docker-compose.yml exec st2client st2 execution list
             docker-compose -f ~/st2-docker/docker-compose.yml exec stackstorm st2 execution list
       - run:
           name: Run tests on production version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             echo "Cloning ${ST2_DOCKER_BRANCH:-master} branch of st2-docker"
             git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
       - run:
-          name: Configufe docker compsoe config
+          name: Configufe docker compose config
           command: |
             # Configure allow origin in the user config
             echo "[api]" > ~/st2-docker/files/st2.user.conf

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ We're using [zombie](https://github.com/assaf/zombie) as our headless browser fo
 
 First of all, you need to make sure you have a running copy of st2 to run tests against. We're using [official docker images](https://github.com/stackstorm/st2-docker) for our automated tests, but the [AIO](https://docs.stackstorm.com/install/index.html) deployment will work just as good (though will take more time to deploy).
 
-To let test runner know the details of your st2 installation, you need to set ST2_HOST, ST2_USERNAME and ST2_PASSWORD env variables, then call `gulp test`.
+To let test runner know the details of your st2 installation, you need to set ST2_PROTOCOL, ST2_HOST, ST2_USERNAME and ST2_PASSWORD env variables, then call `gulp test`.
 
-    $ ST2_HOST=localhost ST2_USERNAME=admin ST2_PASSWORD=123 gulp test
+    $ ST2_PROTOCOL=http ST2_HOST=localhost ST2_USERNAME=admin ST2_PASSWORD=123 gulp test
 
 Copyright, License, and Contributors Agreement
 ----------------------------------------------

--- a/tests/test-history.js
+++ b/tests/test-history.js
@@ -80,7 +80,7 @@ describe('User visits history page', function () {
     let resource;
 
     before(() => {
-      resource = browser.resources.filter((e) => new RegExp('^https://example.com/api/v1/executions/\\w+$').test(e.url));
+      resource = browser.resources.filter((e) => new RegExp('^https://example.com/api/v1/executions/\\w+\\?max_result_size=102400$').test(e.url));
     });
 
     it('should make a call to execution endpoint once', () => {

--- a/tests/util.js
+++ b/tests/util.js
@@ -70,7 +70,9 @@ module.exports = function (browser) {
     }
 
     if (url.host() === process.env.ST2_HOST) {
-      response._url = url.host('example.com').toString();
+      // All the tests expect https:// so we just hack that and replace http with https in case
+      // https is not used
+      response._url = url.host('example.com').toString().replace("http://", "https://");
       request.url = response.url;
     }
 

--- a/tests/util.js
+++ b/tests/util.js
@@ -59,10 +59,10 @@ module.exports = function (browser) {
       return new zombie.Response(`angular.module('main').constant('st2Config', {
         hosts: [{
           name: 'Test',
-          url: 'https://${process.env.ST2_HOST}/api',
-          auth: 'https://${process.env.ST2_HOST}/auth',
+          url: '${process.env.ST2_PROTOCOL}://${process.env.ST2_HOST}/api',
+          auth: '${process.env.ST2_PROTOCOL}://${process.env.ST2_HOST}/auth',
         }],
-      });`);
+        });`);
     }
 
     if (url.path().indexOf('/reamaze.js') >= 0) {
@@ -103,11 +103,11 @@ module.exports = function (browser) {
         const api = new API();
 
         client = api.connect({
-          url: `https://${process.env.ST2_HOST}/api`,
-          auth: `https://${process.env.ST2_HOST}/auth`,
+          url: `${process.env.ST2_PROTOCOL}://${process.env.ST2_HOST}/api`,
+          auth: `${process.env.ST2_PROTOCOL}://${process.env.ST2_HOST}/auth`,
         }, process.env.ST2_USERNAME, process.env.ST2_PASSWORD)
           .then(() => api);
-      }
+        }
 
       return client;
     },


### PR DESCRIPTION
WIP attempt to try to get end to end tests to use up to date st2-docker master branch.

Currently they use vastly outdated 1 year old deprecated ``stackstorm/stackstorm`` Docker image + compose setup.