### PR TITLE
logout action should logout user from all tabs

### DIFF
--- a/modules/st2-api/api.js
+++ b/modules/st2-api/api.js
@@ -135,6 +135,9 @@ export class API {
         server: this.server,
         token: this.token,
       }));
+      localStorage.setItem('logged_in',JSON.stringify({
+        loggedIn: true,
+      }));
     }
   }
 
@@ -142,6 +145,8 @@ export class API {
     this.token = null;
     this.server = null;
     localStorage.removeItem('st2Session');
+    localStorage.removeItem('logged_in');
+
   }
 
   isConnected() {

--- a/modules/st2-menu/menu.component.js
+++ b/modules/st2-menu/menu.component.js
@@ -63,9 +63,26 @@ export default class Menu extends React.Component {
     style: componentStyle,
   }
 
+  componentDidMount() {
+    window.addEventListener('storage', this.storageChange());
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('storage',this.storageChange());
+  }
+
   docsLink = 'https://docs.stackstorm.com/'
   supportLink = 'https://forum.stackstorm.com/'
 
+  storageChange () {
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'logged_in' && (event.oldValue !== event.newValue)) {
+        api.disconnect();
+        window.location.reload();
+      }
+    });
+  }
+  
   handleDisconnect() {
     api.disconnect();
     window.location.reload();


### PR DESCRIPTION
Here, token is not getting expired/invalidated after user logout. So application remains open in other tabs event if logout from one tab. If application is accessed in multiple tabs, if we logout application in one tab ,other tab will get signal that application is logout in one of tab so it will automatically get logout from all open tabs.
