### PR TITLE
Allow integer fields with YAQL expressions to be saved

### DIFF
--- a/apps/st2-actions/actions-details.component.js
+++ b/apps/st2-actions/actions-details.component.js
@@ -200,6 +200,18 @@ export default class ActionsDetails extends React.Component {
     return false;
   }
 
+  isExpression (value) {
+    if (value.startsWith('{{') && value.endsWith('}}')) {
+      return true;
+    } 
+    else if (value.startsWith('<%') && value.endsWith('%>')) {
+      return true;
+    } 
+    else {
+      return false;
+    }
+  }
+
   isValidInt (value) {
     for ( let n = 0; n < value.length; n += 1) {
       const digit = (value.charCodeAt(n) >= 48 && value.charCodeAt(n) <= 57)  || value.charCodeAt(n) === 45 || value.charCodeAt(n) === 8;
@@ -280,10 +292,12 @@ export default class ActionsDetails extends React.Component {
             <DetailsToolbar key="toolbar">
               <Button  
                 disabled={ 
-                  (this.state.runValue && this.state.runValue.timeout &&  this.minMax(this.state.runValue.timeout)) || 
-                  (this.state.runValue && this.state.runValue.limit &&  this.minMax(this.state.runValue.limit))  || 
-                  (this.state.runValue && this.state.runValue.timeout &&  this.isValidInt(this.state.runValue.timeout))  ||
-                  (this.state.runValue && this.state.runValue.limit &&  this.isValidInt(this.state.runValue.limit))  
+                  (this.state.runValue && this.state.runValue.timeout && !this.isExpression(this.state.runValue.timeout) && 
+                     (this.isValidInt(this.state.runValue.timeout) ||
+                      this.minMax(this.state.runValue.timeout))) || 
+                  (this.state.runValue && this.state.runValue.limit && !this.isExpression(this.state.runValue.limit) && 
+                     (this.isValidInt(this.state.runValue.limit) ||
+                      this.minMax(this.state.runValue.limit)))
                 }
                 value="Run" data-test="run_submit" onClick={(e) => this.handleRun(e, action.ref, this.state.runValue, this.state.runTrace || undefined)} 
               />

--- a/modules/st2-auto-form/fields/base.js
+++ b/modules/st2-auto-form/fields/base.js
@@ -88,6 +88,8 @@ export class BaseTextField extends React.Component {
       return false;
     }
 
+    return undefined;
+
   }
 
   handleChange(e, value) {

--- a/modules/st2-auto-form/fields/base.js
+++ b/modules/st2-auto-form/fields/base.js
@@ -84,7 +84,10 @@ export class BaseTextField extends React.Component {
       return false;
     }
 
-    return undefined;
+    if (isYaql(v)) {
+      return false;
+    }
+
   }
 
   handleChange(e, value) {

--- a/modules/st2-auto-form/fields/integer.js
+++ b/modules/st2-auto-form/fields/integer.js
@@ -14,13 +14,17 @@
 
 import validator from 'validator';
 
-import { BaseTextField, isJinja } from './base';
+import { BaseTextField, isJinja, isYaql } from './base';
 
 export default class IntegerField extends BaseTextField {
   static icon = '12'
 
   fromStateValue(v) {
     if (isJinja(v)) {
+      return v;
+    }
+
+    if (isYaql(v)) {
       return v;
     }
 
@@ -34,6 +38,10 @@ export default class IntegerField extends BaseTextField {
 
   toStateValue(v) {
     if (isJinja(v)) {
+      return v;
+    }
+
+    if (isYaql(v)) {
       return v;
     }
 

--- a/modules/st2-auto-form/fields/number.js
+++ b/modules/st2-auto-form/fields/number.js
@@ -14,7 +14,7 @@
 
 import validator from 'validator';
 
-import { BaseTextField, isJinja } from './base';
+import { BaseTextField, isJinja, isYaql } from './base';
 
 export default class NumberField extends BaseTextField {
   static icon = '.5'
@@ -24,11 +24,19 @@ export default class NumberField extends BaseTextField {
       return v;
     }
 
+    if (isYaql(v)) {
+      return v;
+    }
+
     return v !== '' ? validator.toFloat(v) : void 0;
   }
 
   toStateValue(v) {
     if (isJinja(v)) {
+      return v;
+    }
+
+    if (isYaql(v)) {
       return v;
     }
 

--- a/modules/st2-auto-form/fields/object.js
+++ b/modules/st2-auto-form/fields/object.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import _ from 'lodash';
-import { BaseTextareaField, isJinja } from './base';
+import { BaseTextareaField, isJinja, isYaql } from './base';
 
 export default class ObjectField extends BaseTextareaField {
   static icon = '{ }'
@@ -23,11 +23,19 @@ export default class ObjectField extends BaseTextareaField {
       return v;
     }
 
+    if (isYaql(v)) {
+      return v;
+    }
+
     return v !== '' && v !== undefined ? JSON.parse(v) : void 0;
   }
 
   toStateValue(v) {
     if (isJinja(v)) {
+      return v;
+    }
+
+    if (isYaql(v)) {
       return v;
     }
 


### PR DESCRIPTION
If we have an action that requires an integer or number as a parameter, and then we have a workflow that calls that action. Currently if we put a YAQL expression such as <% ctx().int_param %> as the value for the parameter, we will get an error stating that it is not a valid integer or float. 
Update the workflow composer so that it handles integer parameters and numbers with YAQL in the same way it handles Jinja.

Similar change made for objects. No change needed for booleans, but to put in YAQL or Jinja with booleans have to code to the YAML view.