### PR TITLE
Resolved auto refresh list of actions issue after delete action

### DIFF
--- a/apps/st2-actions/actions-panel.component.js
+++ b/apps/st2-actions/actions-panel.component.js
@@ -223,6 +223,7 @@ export default class ActionsPanel extends React.Component {
           notification.success(`Action "${ref}" has been deleted successfully.`);
           this.navigate({ id: null });
           store.dispatch(flexActions.toggleAll());
+          this.fetchGroups();
           return res;
         })
         .catch((err) => {


### PR DESCRIPTION
There is issue for auto refresh of actions list after delete action. I am calling API after successful deletion which fetch list of actions so all updated actions will display right.