### PR TITLE
Resolved issue to keep left pack menu of action list expanded after s…

### DIFF
--- a/apps/st2-actions/actions-panel.component.js
+++ b/apps/st2-actions/actions-panel.component.js
@@ -222,7 +222,6 @@ export default class ActionsPanel extends React.Component {
         .then((res) => {
           notification.success(`Action "${ref}" has been deleted successfully.`);
           this.navigate({ id: null });
-          store.dispatch(flexActions.toggleAll());
           this.fetchGroups();
           return res;
         })


### PR DESCRIPTION
I have removed changes that pack menu gets collapsed after action delete and added changes to keep pack menu as expanded even after successful deletion of action, So that If user wants to delete more actions from same expanded pack there will no need to again open that pack menu.