### PR TITLE
Add link to trigger on History page

### DIFF
--- a/apps/st2-history/history-details.component.js
+++ b/apps/st2-history/history-details.component.js
@@ -216,7 +216,7 @@ export default class HistoryDetails extends React.Component {
                   <DetailsPanelBody>
                     { execution.trigger.type ? (
                       <DetailsPanelBodyLine label="Trigger">
-                        { execution.trigger.type }
+                        <Link to={`/triggers/${execution.trigger.type}`}>{execution.trigger.type}</Link>
                       </DetailsPanelBodyLine>
                     ) : null }
                     { execution.trigger_instance && execution.trigger_instance.occurrence_time ? (


### PR DESCRIPTION
On the History page, there is a TRIGGER DETAILS section on the lower right.
The Trigger name is displayed but it would be better it linked to the actual Trigger page.
This PR turns the Trigger name into a link.