### PR TITLE
fix: Save workflow error when updating with parameters

### DIFF
--- a/apps/st2-actions/actions-panel.component.js
+++ b/apps/st2-actions/actions-panel.component.js
@@ -303,7 +303,6 @@ export default class ActionsPanel extends React.Component {
         </PanelView>
 
         <ActionsDetails
-          ref={(ref) => this._details = ref}
           handleNavigate={(...args) => this.navigate(...args)}
           handleRun={(...args) => this.handleRun(...args)}
           handleDelete={(...arg) => this.handleDelete(...arg)}

--- a/apps/st2-history/history-panel.component.js
+++ b/apps/st2-history/history-panel.component.js
@@ -531,7 +531,6 @@ export default class HistoryPanel extends React.Component {
         </PanelView>
 
         <HistoryDetails
-          ref={(ref) => this._details = ref}
           handleNavigate={(...args) => this.navigate(...args)}
           handleRerun={(...args) => this.handleRerun(...args)}
           handleCancel={(...args) => this.handleCancel(...args)}

--- a/apps/st2-rules/rules-panel.component.js
+++ b/apps/st2-rules/rules-panel.component.js
@@ -281,7 +281,6 @@ export default class RulesPanel extends React.Component {
         </PanelView>
 
         <RulesDetails
-          ref={(ref) => this._details = ref}
           onNavigate={(...args) => this.navigate(...args)}
 
           id={id}

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -271,7 +271,7 @@ export default class Workflows extends Component {
        if (meta.parameters) {
          Object.keys(meta.parameters).forEach(key => {
            if (meta.parameters[key]._name) {
-            delete meta.parameters[key]._name;
+             delete meta.parameters[key]._name;
            }
          });
        }

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -266,6 +266,16 @@ export default class Workflows extends Component {
 
    const promise = (async () => {
      if (existingAction) {
+
+       // remove "_name" key from parameter keys for successful request
+       if (meta.parameters) {
+         Object.keys(meta.parameters).forEach(key => {
+           if (meta.parameters[key]._name) {
+            delete meta.parameters[key]._name;
+           }
+         });
+       }
+
        await api.request({ method: 'put', path: `/actions/${pack}.${meta.name}` }, meta);
      }
      else {


### PR DESCRIPTION
Fixes issue [862]( https://github.com/StackStorm/st2web/issues/862)

Saving a workflow immediately after creating and running it causes a 400 HTTP response code for a bad request. There is an extra property in the PUT request body that is not supported by the API. Finer details and replication steps can be found within the issue. These changes removes the `_name` property from the request body, resulting in a successful "save".

This also fixes some react errors regarding `ref`; it cannot be used for function components, and the `_details` variable is not defined either.

React Error Example (when loading multiple pages):
![Screen Shot 2022-02-28 at 10 14 37 AM](https://user-images.githubusercontent.com/46300738/156011720-ac98770b-736a-451c-b8f2-4effd40e847a.png)
