### PR TITLE
Hotkey Shortcuts and Open in New Tab/Window

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Added
 
   Contributed by @ParthS007
 
+* Added new Hotkey Shortcuts for Workflow Designer: Save (ctrl/cmd + s), Open (ctrl/cmd + o),
+  Undo/Redo (ctrl/cmd + z, shift + z), Copy/Cut/Paste (ctrl/cmd + c/x/v). #963, #991
+
+  Contributed by @Jappzy and @cded from @Bitovi
+
 Changed
 ~~~~~~~
 * Updated nodejs from `14.16.1` to `14.20.1`, fixing the local build under ARM processor architecture. #880

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -17,7 +17,6 @@ import React, { Component } from 'react';
 // import ReactDOM from 'react-dom';
 import { Provider, connect } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { HotKeys } from 'react-hotkeys';
 import { mapValues, get } from 'lodash';
 import cx from 'classnames';
 import url from 'url';
@@ -283,17 +282,6 @@ export default class Workflows extends Component {
 
   style = style
 
-  keyMap = {
-    copy: [ 'ctrl+c', 'command+c', 'meta+c' ],
-    cut: [ 'ctrl+x', 'command+x', 'meta+x' ],
-    paste: [ 'ctrl+v', 'command+v', 'meta+v' ],
-    open: [ 'ctrl+o', 'command+o', 'meta+o' ],
-    undo: [ 'ctrl+z', 'command+z', 'meta+z' ],
-    redo: [ 'ctrl+shift+z', 'command+shift+z', 'meta+shift+z' ],
-    save: [ 'ctrl+s', 'command+s', 'meta+s' ],
-    handleTaskDelete: [ 'del', 'backspace' ],
-  }
-
   keyHandlers = {
     undo: () => {
       store.dispatch({ type: 'FLOW_UNDO' });
@@ -349,10 +337,8 @@ export default class Workflows extends Component {
                 <Menu location={location} routes={this.props.routes} /> 
                 <div className="component-row-content">
                   { !isCollapsed.palette && <Palette className="palette" actions={actions} /> }
-                  <HotKeys
+                  <div
                     style={{ flex: 1}}
-                    keyMap={this.keyMap}
-                    handlers={this.keyHandlers}
                   >
                     <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} save={this.keyHandlers.save} dirtyflag={this.props.dirty} undo={this.keyHandlers.undo} redo={this.keyHandlers.redo}>
                       <Toolbar>
@@ -404,7 +390,7 @@ export default class Workflows extends Component {
                         </ToolbarDropdown>
                       </Toolbar>
                     </Canvas>
-                  </HotKeys>
+                  </div>
                   { !isCollapsed.details && <Details className="details" actions={actions} /> }
                 </div>
               </div>

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -302,9 +302,14 @@ export default class Workflows extends Component {
       store.dispatch({ type: 'FLOW_REDO' });
     },
     save: (x) => {
-      x.preventDefault();
-      x.stopPropagation();
-      this.save().then(() => null);
+      if (x) {
+        x.preventDefault();
+        x.stopPropagation();
+      }
+
+      this.save()
+        .then(() => store.dispatch({ type: 'PUSH_SUCCESS', source: 'icon-save', message: 'Workflow saved.' }))
+        .catch(() => store.dispatch({ type: 'PUSH_SUCCESS', source: 'icon-save', message: 'Error saving workflow.' }));
     },
     copy: () => {
       store.dispatch({ type: 'PUSH_WARNING', source: 'icon-save', message: 'Select a task to copy' });
@@ -344,7 +349,7 @@ export default class Workflows extends Component {
                     keyMap={this.keyMap}
                     handlers={this.keyHandlers}
                   >
-                    <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} saveData={e => this.save()} dirtyflag={this.props.dirty} undo={this.keyHandlers.undo} redo={this.keyHandlers.redo}>
+                    <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} save={this.keyHandlers.save} dirtyflag={this.props.dirty} undo={this.keyHandlers.undo} redo={this.keyHandlers.redo}>
                       <Toolbar>
                         <ToolbarButton key="undo" icon="icon-redirect" title="Undo" errorMessage="Could not undo." onClick={() => undo()} />
                         <ToolbarButton key="redo" icon="icon-redirect2" title="Redo" errorMessage="Could not redo." onClick={() => redo()} />

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -34,18 +34,6 @@ import globalStore from '@stackstorm/module-store';
 import store from './store';
 import style from './style.css';
 
-function guardKeyHandlers(obj, names) {
-  const filteredObj = pick(obj, names);
-  return mapValues(filteredObj, fn => {
-    return e => {
-      if(e.target === document.body) {
-        e.preventDefault();
-        fn.call(obj);
-      }
-    };
-  });
-}
-
 const POLL_INTERVAL = 5000;
 
 @connect(
@@ -296,9 +284,37 @@ export default class Workflows extends Component {
   style = style
 
   keyMap = {
-    undo: [ 'ctrl+z', 'meta+z' ],
-    redo: [ 'ctrl+shift+z', 'meta+shift+z' ],
+    copy: [ 'ctrl+c', 'command+c', 'meta+c' ],
+    cut: [ 'ctrl+x', 'command+x', 'meta+x' ],
+    paste: [ 'ctrl+v', 'command+v', 'meta+v' ],
+    open: [ 'ctrl+o', 'command+o', 'meta+o' ],
+    undo: [ 'ctrl+z', 'command+z', 'meta+z' ],
+    redo: [ 'ctrl+shift+z', 'command+shift+z', 'meta+shift+z' ],
+    save: [ 'ctrl+s', 'command+s', 'meta+s' ],
     handleTaskDelete: [ 'del', 'backspace' ],
+  }
+
+  keyHandlers = {
+    undo: () => {
+      store.dispatch({ type: 'FLOW_UNDO' });
+    },
+    redo: () => {
+      store.dispatch({ type: 'FLOW_REDO' });
+    },
+    save: (x) => {
+      x.preventDefault();
+      x.stopPropagation();
+      this.save().then(() => null);
+    },
+    copy: () => {
+      store.dispatch({ type: 'PUSH_WARNING', source: 'icon-save', message: 'Select a task to copy' });
+    },
+    cut: () => {
+      store.dispatch({ type: 'PUSH_WARNING', source: 'icon-save', message: 'Nothing to cut' });
+    },
+    paste: () => {
+      store.dispatch({ type: 'PUSH_WARNING', source: 'icon-save', message: 'Nothing to paste' });
+    },
   }
 
   render() {
@@ -326,8 +342,7 @@ export default class Workflows extends Component {
                   <HotKeys
                     style={{ flex: 1}}
                     keyMap={this.keyMap}
-                    attach={document.body}
-                    handlers={guardKeyHandlers(this.props, [ 'undo', 'redo' ])}
+                    handlers={this.keyHandlers}
                   >
                     <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} saveData={e => this.save()} dirtyflag={this.props.dirty}>
                       <Toolbar>

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -18,7 +18,7 @@ import React, { Component } from 'react';
 import { Provider, connect } from 'react-redux';
 import { PropTypes } from 'prop-types';
 import { HotKeys } from 'react-hotkeys';
-import { pick, mapValues, get } from 'lodash';
+import { mapValues, get } from 'lodash';
 import cx from 'classnames';
 import url from 'url';
 import Menu from '@stackstorm/module-menu';

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -273,7 +273,7 @@ export default class Workflows extends Component {
      // don't need to return anything to the store. the handler will change dirty.
      return {};
    })();
-  
+
    store.dispatch({
      type: 'SAVE_WORKFLOW',
      promise,
@@ -301,15 +301,20 @@ export default class Workflows extends Component {
     redo: () => {
       store.dispatch({ type: 'FLOW_REDO' });
     },
-    save: (x) => {
+    save: async (x) => {
       if (x) {
         x.preventDefault();
         x.stopPropagation();
       }
 
-      this.save()
-        .then(() => store.dispatch({ type: 'PUSH_SUCCESS', source: 'icon-save', message: 'Workflow saved.' }))
-        .catch(() => store.dispatch({ type: 'PUSH_SUCCESS', source: 'icon-save', message: 'Error saving workflow.' }));
+      try {
+        await this.save();
+        store.dispatch({ type: 'PUSH_SUCCESS', source: 'icon-save', message: 'Workflow saved.' });
+      }
+      catch(e) {
+        const faultString = get(e, 'response.data.faultstring');
+        store.dispatch({ type: 'PUSH_ERROR', source: 'icon-save', error: `Error saving workflow: ${faultString}` });
+      }
     },
     copy: () => {
       store.dispatch({ type: 'PUSH_WARNING', source: 'icon-save', message: 'Select a task to copy' });

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -344,7 +344,7 @@ export default class Workflows extends Component {
                     keyMap={this.keyMap}
                     handlers={this.keyHandlers}
                   >
-                    <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} saveData={e => this.save()} dirtyflag={this.props.dirty}>
+                    <Canvas className="canvas" location={location} match={match} fetchActionscalled={e => this.props.fetchActions()} saveData={e => this.save()} dirtyflag={this.props.dirty} undo={this.keyHandlers.undo} redo={this.keyHandlers.redo}>
                       <Toolbar>
                         <ToolbarButton key="undo" icon="icon-redirect" title="Undo" errorMessage="Could not undo." onClick={() => undo()} />
                         <ToolbarButton key="redo" icon="icon-redirect2" title="Redo" errorMessage="Could not redo." onClick={() => redo()} />

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -719,13 +719,13 @@ export default class Canvas extends Component {
         focused={true}
         attach={document.body}
         keyMap={{
-          copy: [ 'ctrl+c', 'command+c', 'meta+c' ],
-          cut: [ 'ctrl+x', 'command+x', 'meta+x' ],
-          paste: [ 'ctrl+v', 'command+v', 'meta+v' ],
-          open: [ 'ctrl+o', 'command+o', 'meta+o' ],
-          undo: [ 'ctrl+z', 'command+z', 'meta+z' ],
-          redo: [ 'ctrl+shift+z', 'command+shift+z', 'meta+shift+z' ],
-          save: [ 'ctrl+s', 'command+s', 'meta+s' ],
+          copy: [ 'ctrl+c', 'command+c' ],
+          cut: [ 'ctrl+x', 'command+x' ],
+          paste: [ 'ctrl+v', 'command+v' ],
+          open: [ 'ctrl+o', 'command+o' ],
+          undo: [ 'ctrl+z', 'command+z' ],
+          redo: [ 'ctrl+shift+z', 'command+shift+z' ],
+          save: [ 'ctrl+s', 'command+s' ],
         }}
         handlers={{
           copy: () => {
@@ -752,7 +752,7 @@ export default class Canvas extends Component {
 
               const newCoords = {
                 x: taskCoords.x,
-                y: taskCoords.y + taskHeight + 10
+                y: taskCoords.y + taskHeight + 10,
               };
 
               const lastIndex = tasks
@@ -781,7 +781,7 @@ export default class Canvas extends Component {
             e.preventDefault();
             e.stopPropagation();
             this.props.save();
-          }
+          },
         }}
       >
         <div

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -738,6 +738,11 @@ export default class Canvas extends Component {
             }
           },
           paste: () => {
+            if (document.activeElement.tagName === 'TEXTAREA' || document.activeElement.tagName === 'INPUT') {
+              // allow regular copy/paste from clipboard when inputs or textareas are focused
+              return;
+            }
+
             const { copiedTask } = this.state;
             if (copiedTask) {
               const taskHeight = copiedTask.size.y;

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -231,6 +231,7 @@ export default class Canvas extends Component {
     saveData: PropTypes.func,
     undo: PropTypes.func,
     redo: PropTypes.func,
+    save: PropTypes.func,
   }
 
   state = {
@@ -724,6 +725,7 @@ export default class Canvas extends Component {
           open: [ 'ctrl+o', 'command+o', 'meta+o' ],
           undo: [ 'ctrl+z', 'command+z', 'meta+z' ],
           redo: [ 'ctrl+shift+z', 'command+shift+z', 'meta+shift+z' ],
+          save: [ 'ctrl+s', 'command+s', 'meta+s' ],
         }}
         handlers={{
           copy: () => {
@@ -775,6 +777,11 @@ export default class Canvas extends Component {
           redo: () => {
             this.props.redo();
           },
+          save: (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.props.save();
+          }
         }}
       >
         <div

--- a/modules/st2flow-palette/action.js
+++ b/modules/st2flow-palette/action.js
@@ -67,11 +67,22 @@ export default class Action extends Component<{
 
   render() {
     const { action } = this.props;
+    const supportedRunnerTypes = {
+      'orquesta': href,
+      'mistral-v2': href
+    };
+
     return (
-      <div className={this.style.action} ref={this.actionRef} draggable>
+      <a
+        draggable
+        className={this.style.action}
+        ref={this.actionRef}
+        href={supportedRunnerTypes[action.runner_type]}
+        target="_blank"
+        rel="noopener noreferrer">
         <div className={this.style.actionName}>{ action.ref }</div>
         <div className={this.style.actionDescription}>{ action.description }</div>
-      </div>
+      </a>
     );
   }
 }

--- a/modules/st2flow-palette/action.js
+++ b/modules/st2flow-palette/action.js
@@ -67,6 +67,9 @@ export default class Action extends Component<{
 
   render() {
     const { action } = this.props;
+
+    const href = `${location.origin}/#/action/${action.ref}`;
+
     const supportedRunnerTypes = {
       'orquesta': href,
       'mistral-v2': href

--- a/modules/st2flow-palette/action.js
+++ b/modules/st2flow-palette/action.js
@@ -76,7 +76,7 @@ export default class Action extends Component<{
     };
 
     return (
-      <a
+      <div
         draggable
         className={this.style.action}
         ref={this.actionRef}
@@ -85,7 +85,7 @@ export default class Action extends Component<{
         rel="noopener noreferrer">
         <div className={this.style.actionName}>{ action.ref }</div>
         <div className={this.style.actionDescription}>{ action.description }</div>
-      </a>
+      </div>
     );
   }
 }

--- a/modules/st2flow-palette/style.css
+++ b/modules/st2flow-palette/style.css
@@ -35,6 +35,8 @@ limitations under the License.
 
   position: relative;
 
+  display: block;
+
   &-name {
     color: #2d2d2d;
     font-size: 14px;

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -21,7 +21,7 @@ const plugins = require('gulp-load-plugins')(settings.plugins);
 
 gulp.task('lint', (done) => gulp.src(settings.lint, { cwd: settings.dev })
   .pipe(plugins.plumber())
-  .pipe(plugins.eslint())
+  .pipe(plugins.eslint({ fix: true }))
   .pipe(plugins.eslint.format())
   .pipe(plugins.eslint.failAfterError())
   .on('end', () => done())


### PR DESCRIPTION
Resolves #917
Closes #991

Adds hotkey shortcuts for the following functionality:
- Save (ctrl/cmd + s): Shortcut alternative to manually clicking the save button
- Open (ctrl/cmd + o): When an orquesta workflow is selected, this will open it in a new tab
- Undo/Redo (ctrl/cmd + z, shift + z): Shortcut alternative to manually clicking the undo and redo buttons in the toolbar
- Copy/Cut/Paste (ctrl/cmd + c/x/v): Copy, Cut, and Paste workflow actions in the composer workspace

Also adds click functionality for actions in the left side-panel to easily open in new tabs/windows.

This screen recording demonstrates the save shortcut, then copy/cut/paste, then undo/redo, and then opening orquesta workflow in a new tab from click and then shortcut:

https://user-images.githubusercontent.com/46300738/163048338-6962f953-919c-49b2-b0a1-7609dea1ef69.mov


