### PR TITLE
Search Criteria Support in the Web UI

### DIFF
--- a/apps/st2-rules/rules-details.component.js
+++ b/apps/st2-rules/rules-details.component.js
@@ -207,6 +207,8 @@ export default class RulesDetails extends React.Component {
     }
 
     this.props.onComponentUpdate && this.props.onComponentUpdate();
+
+    this.setState({ editing: null });
   }
 
   handleSection(section) {
@@ -440,8 +442,8 @@ export default class RulesDetails extends React.Component {
                         ? (
                           Object.keys(rule.criteria || {})
                             .map(name => {
-                              const { type, pattern } = rule.criteria[name];
-                              return <DetailsCriteriaLine key={`${name}//${type}//${pattern}`} name={name} type={type} pattern={pattern} />;
+                              const { type, pattern, condition } = rule.criteria[name];
+                              return <DetailsCriteriaLine key={`${name}//${type}//${pattern}`} name={name} type={type} pattern={pattern} condition={condition} />;
                             })
                         ) : (
                           <DetailsLineNote>

--- a/modules/st2-criteria/criteria.component.js
+++ b/modules/st2-criteria/criteria.component.js
@@ -1,13 +1,13 @@
 // Copyright 2019 Extreme Networks, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an 'AS IS' BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -55,8 +55,8 @@ const types = {
 };
 
 const searchConditions = {
-  'any': "Any",
-  'all': "All",
+  'any': 'Any',
+  'all': 'All',
 };
 
 export default class Criteria extends React.Component {
@@ -80,7 +80,7 @@ export default class Criteria extends React.Component {
       ...data,
       [key]: {
         ...data[key],
-        condition
+        condition,
       },
     });
   }
@@ -93,12 +93,12 @@ export default class Criteria extends React.Component {
       [key]: {
         ...data[key],
         pattern: {
-          ...data[key]['pattern'],
+          ...data[key].pattern,
           ['item.data']: {
-            ...data[key]['pattern']['item.data'],
+            ...data[key].pattern['item.data'],
             pattern,
-          }
-        }
+          },
+        },
       },
     });
   }
@@ -111,12 +111,12 @@ export default class Criteria extends React.Component {
       [key]: {
         ...data[key],
         pattern: {
-          ...data[key]['pattern'],
+          ...data[key].pattern,
           ['item.data']: {
-            ...data[key]['pattern']['item.data'],
+            ...data[key].pattern['item.data'],
             type,
-          }
-        }
+          },
+        },
       },
     });
   }
@@ -204,10 +204,10 @@ export default class Criteria extends React.Component {
                 }}
                 onChange={(value) => this.handleChangeType(key, value)}
               />
-                            { type === 'search' ? (
+              { type === 'search' ? (
                 <>
                   <AutoFormSelect
-                    name="Condition"
+                    name='Condition'
                     className={style.entity}
                     disabled={disabled}
                     data={condition}
@@ -218,20 +218,20 @@ export default class Criteria extends React.Component {
                     onChange={(value) => this.handleChangeSearchCondition(key, value)}
                   />
                   <AutoFormInput
-                    name={"Pattern"}
+                    name={'Pattern'}
                     className={style.entity}
                     disabled={disabled}
-                    data={pattern['item.data'] ? pattern['item.data'].pattern : ""}
+                    data={pattern['item.data'] ? pattern['item.data'].pattern : ''}
                     spec={{
                       required: true,
                     }}
                     onChange={(value) => this.handleChangeSearchPattern(key, value)}
                   />
                   <AutoFormSelect
-                    name={"Type"}
+                    name={'Type'}
                     className={style.entity}
                     disabled={disabled}
-                    data={pattern['item.data'] ? pattern['item.data'].type : ""}
+                    data={pattern['item.data'] ? pattern['item.data'].type : ''}
                     spec={{
                       required: true,
                       enum: types,
@@ -259,10 +259,10 @@ export default class Criteria extends React.Component {
         { disabled ? null : (
           <div className={style.buttons}>
             <input
-              type="button"
-              className="st2-forms__button st2-forms__button--small"
+              type='button'
+              className='st2-forms__button st2-forms__button--small'
               onClick={() => this.handleAdd()}
-              value="Add criteria"
+              value='Add criteria'
             />
           </div>
         ) }

--- a/modules/st2-criteria/criteria.component.js
+++ b/modules/st2-criteria/criteria.component.js
@@ -136,13 +136,35 @@ export default class Criteria extends React.Component {
   handleChangeType(key, type) {
     const { data, onChange } = this.props;
 
-    return onChange({
-      ...data,
-      [key]: {
-        ...data[key],
-        type,
-      },
-    });
+    if (type === 'search') {
+      // save default values for search criteria
+      return onChange({
+        ...data,
+        [key]: {
+          ...data[key],
+          type,
+          condition: 'all',
+          pattern: {
+            ...data[key]['pattern'],
+            ['item.data']: {
+              ...data[key]['pattern']['item.data'],
+              type: Object.keys(types)[0],
+            }
+          }
+        },
+      });
+    } else {
+      // reset pattern from object to empty string if type != 'search'
+      this.handleChangePattern(key, '');
+      return onChange({
+        ...data,
+        [key]: {
+          ...data[key],
+          type,
+          pattern: '',
+        },
+      });
+    }
   }
 
   handleChangePattern(key, pattern) {

--- a/modules/st2-criteria/criteria.component.js
+++ b/modules/st2-criteria/criteria.component.js
@@ -145,15 +145,16 @@ export default class Criteria extends React.Component {
           type,
           condition: 'all',
           pattern: {
-            ...data[key]['pattern'],
+            ...data[key].pattern,
             ['item.data']: {
-              ...data[key]['pattern']['item.data'],
+              ...data[key].pattern['item.data'],
               type: Object.keys(types)[0],
-            }
-          }
+            },
+          },
         },
       });
-    } else {
+    }
+    else {
       // reset pattern from object to empty string if type != 'search'
       this.handleChangePattern(key, '');
       return onChange({

--- a/modules/st2-criteria/criteria.component.js
+++ b/modules/st2-criteria/criteria.component.js
@@ -1,13 +1,13 @@
 // Copyright 2019 Extreme Networks, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the 'License');
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an 'AS IS' BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.

--- a/modules/st2-criteria/criteria.component.js
+++ b/modules/st2-criteria/criteria.component.js
@@ -51,6 +51,12 @@ const types = {
   'timediff_gt': 'Later Than',
   'exists': 'Exists',
   'nexists': 'Doesn\'t Exist',
+  'search': 'Search',
+};
+
+const searchConditions = {
+  'any': "Any",
+  'all': "All",
 };
 
 export default class Criteria extends React.Component {
@@ -65,6 +71,54 @@ export default class Criteria extends React.Component {
 
   static defaultProps = {
     disabled: false,
+  }
+
+  handleChangeSearchCondition(key, condition) {
+    const { data, onChange } = this.props;
+
+    return onChange({
+      ...data,
+      [key]: {
+        ...data[key],
+        condition
+      },
+    });
+  }
+
+  handleChangeSearchPattern(key, pattern) {
+    const { data, onChange } = this.props;
+
+    return onChange({
+      ...data,
+      [key]: {
+        ...data[key],
+        pattern: {
+          ...data[key]['pattern'],
+          ['item.data']: {
+            ...data[key]['pattern']['item.data'],
+            pattern,
+          }
+        }
+      },
+    });
+  }
+
+  handleChangeSearchType(key, type) {
+    const { data, onChange } = this.props;
+
+    return onChange({
+      ...data,
+      [key]: {
+        ...data[key],
+        pattern: {
+          ...data[key]['pattern'],
+          ['item.data']: {
+            ...data[key]['pattern']['item.data'],
+            type,
+          }
+        }
+      },
+    });
   }
 
   handleChangeKey(oldKey, key) {
@@ -131,7 +185,7 @@ export default class Criteria extends React.Component {
     return (
       <div {...props} className={cx(style.component, flat && [ 'st2-auto-form--flat', style.flat ], className)}>
         <div>
-          { _.map(data, ({ type, pattern }, key) => (
+          { _.map(data, ({ type, pattern, condition }, key) => (
             <div className={style.line} key={key}>
               <AutoFormCombobox
                 className={style.entity}
@@ -150,15 +204,52 @@ export default class Criteria extends React.Component {
                 }}
                 onChange={(value) => this.handleChangeType(key, value)}
               />
-              <AutoFormInput
-                className={style.entity}
-                disabled={disabled}
-                data={pattern}
-                spec={{
-                  required: true,
-                }}
-                onChange={(value) => this.handleChangePattern(key, value)}
-              />
+                            { type === 'search' ? (
+                <>
+                  <AutoFormSelect
+                    name="Condition"
+                    className={style.entity}
+                    disabled={disabled}
+                    data={condition}
+                    spec={{
+                      required: true,
+                      enum: searchConditions,
+                    }}
+                    onChange={(value) => this.handleChangeSearchCondition(key, value)}
+                  />
+                  <AutoFormInput
+                    name={"Pattern"}
+                    className={style.entity}
+                    disabled={disabled}
+                    data={pattern['item.data'] ? pattern['item.data'].pattern : ""}
+                    spec={{
+                      required: true,
+                    }}
+                    onChange={(value) => this.handleChangeSearchPattern(key, value)}
+                  />
+                  <AutoFormSelect
+                    name={"Type"}
+                    className={style.entity}
+                    disabled={disabled}
+                    data={pattern['item.data'] ? pattern['item.data'].type : ""}
+                    spec={{
+                      required: true,
+                      enum: types,
+                    }}
+                    onChange={(value) => this.handleChangeSearchType(key, value)}
+                  />
+                </>
+              ) : (
+                <AutoFormInput
+                  className={style.entity}
+                  disabled={disabled}
+                  data={pattern}
+                  spec={{
+                    required: true,
+                  }}
+                  onChange={(value) => this.handleChangePattern(key, value)}
+                />
+              )}
               { disabled ? null :
                 <i className={cx('icon-cross', style.remove)} onClick={() => this.handleRemove(key)} />
               }

--- a/modules/st2-panel/panel.component.js
+++ b/modules/st2-panel/panel.component.js
@@ -370,11 +370,18 @@ export class DetailsCriteriaLine extends React.Component {
   static propTypes = {
     name: PropTypes.string,
     type: PropTypes.string,
-    pattern: PropTypes.string,
+    pattern: PropTypes.any,
+    condition: PropTypes.string,
   }
 
   render() {
-    const { name, type, pattern } = this.props;
+    const { name, type, pattern, condition } = this.props;
+
+    const search = type !== "search" ? null : {
+      condition,
+      pattern: pattern["item.data"].pattern,
+      type: pattern["item.data"].type
+    };
 
     return (
       <div className="st2-details__line">
@@ -385,7 +392,15 @@ export class DetailsCriteriaLine extends React.Component {
           { type }
         </div>
         <div className="st2-details__line-value">
-          { pattern }
+          { search ? (
+            <>
+              Condition: <strong>{search.condition}</strong>
+              <br/>
+              Pattern: <strong>{search.pattern}</strong>
+              <br/>
+              Type: <strong>{search.type}</strong>
+            </>
+          ) : pattern }
         </div>
       </div>
     );

--- a/modules/st2-panel/panel.component.js
+++ b/modules/st2-panel/panel.component.js
@@ -1,13 +1,13 @@
 // Copyright 2019 Extreme Networks, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the 'License');
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an 'AS IS' BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.

--- a/modules/st2-panel/panel.component.js
+++ b/modules/st2-panel/panel.component.js
@@ -1,13 +1,13 @@
 // Copyright 2019 Extreme Networks, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the 'License');
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an 'AS IS' BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -174,9 +174,9 @@ export class ToolbarSearch extends React.Component {
       <div {...props} className={cx('st2-panel__toolbar-search', className)}>
         <form>
           <input
-            type="search"
+            type='search'
             className={cx('st2-panel__search-bar', { 'st2-panel__search-bar--hidden': hidden })}
-            data-test="filter"
+            data-test='filter'
             placeholder={title}
             value={value}
             onChange={(e) => onChange && onChange(e)}
@@ -250,7 +250,7 @@ export class Content extends React.Component {
 
     return (
       <div {...props} className={cx('st2-panel__content', className)}>
-        <div className="st2-panel__scroller" ref={(ref) => this._scroller = ref}>
+        <div className='st2-panel__scroller' ref={(ref) => this._scroller = ref}>
           { children }
         </div>
       </div>
@@ -289,15 +289,15 @@ export class DetailsHeader extends React.Component {
 
     return (
       <div {...props} className={cx('st2-details__header', className)}>
-        <div className="st2-details__header-name">
+        <div className='st2-details__header-name'>
           { status ? (
-            <Label className="st2-details__header-label" status={status} short data-test="status" />
+            <Label className='st2-details__header-label' status={status} short data-test='status' />
           ) : null }
-          <div data-test="header_name">
+          <div data-test='header_name'>
             { title }
           </div>
         </div>
-        <div className="st2-details__header-description" data-test="header_description">
+        <div className='st2-details__header-description' data-test='header_description'>
           { subtitle }
         </div>
         { children }
@@ -358,7 +358,7 @@ export class DetailsBody extends React.Component {
 
     return (
       <div {...props} className={cx('st2-details__body', 'st2-details__body--active', className)}>
-        <div className="st2-panel__scroller">
+        <div className='st2-panel__scroller'>
           { children }
         </div>
       </div>
@@ -377,21 +377,21 @@ export class DetailsCriteriaLine extends React.Component {
   render() {
     const { name, type, pattern, condition } = this.props;
 
-    const search = type !== "search" ? null : {
+    const search = type !== 'search' ? null : {
       condition,
-      pattern: pattern["item.data"].pattern,
-      type: pattern["item.data"].type
+      pattern: pattern['item.data'].pattern,
+      type: pattern['item.data'].type
     };
 
     return (
-      <div className="st2-details__line">
-        <div className="st2-details__line-key">
+      <div className='st2-details__line'>
+        <div className='st2-details__line-key'>
           { name }
         </div>
-        <div className="st2-details__line-type">
+        <div className='st2-details__line-type'>
           { type }
         </div>
-        <div className="st2-details__line-value">
+        <div className='st2-details__line-value'>
           { search ? (
             <>
               Condition: <strong>{search.condition}</strong>
@@ -447,11 +447,11 @@ export class DetailsLine extends React.Component {
     }
 
     return (
-      <div className="st2-details__line">
-        <div className="st2-details__line-name">
+      <div className='st2-details__line'>
+        <div className='st2-details__line-name'>
           { name }
         </div>
-        <div className="st2-details__line-value">
+        <div className='st2-details__line-value'>
           { value }
         </div>
       </div>
@@ -466,7 +466,7 @@ export class DetailsLineNote extends React.Component {
 
   render() {
     return (
-      <div className="st2-details__line-note">
+      <div className='st2-details__line-note'>
         { this.props.children }
       </div>
     );
@@ -524,7 +524,7 @@ export class DetailsPanelHeading extends React.Component {
 
     return (
       <div {...props} className={cx('st2-details__panel-heading', className)}>
-        <h2 className="st2-details__panel-title">{ title }</h2>
+        <h2 className='st2-details__panel-title'>{ title }</h2>
         <div>{ children }</div>
       </div>
     );
@@ -560,8 +560,8 @@ export class DetailsPanelBodyLine extends React.Component {
 
     return (
       <dl {...props} className={cx('st2-details__panel-body-line', className)}>
-        <dt className="st2-details__panel-body-label">{ label }</dt>
-        <dd className="st2-details__panel-body-value">{ children }</dd>
+        <dt className='st2-details__panel-body-label'>{ label }</dt>
+        <dd className='st2-details__panel-body-value'>{ children }</dd>
       </dl>
     );
   }
@@ -636,7 +636,7 @@ export class ToggleButton extends React.Component {
           'st2-panel__toolbar-toggle-all--collapsed': collapsed,
         })}
         onClick={(e) => onClick(e)}
-        data-test="toggle-all"
+        data-test='toggle-all'
       />
     );
   }

--- a/modules/st2-panel/panel.component.js
+++ b/modules/st2-panel/panel.component.js
@@ -380,7 +380,7 @@ export class DetailsCriteriaLine extends React.Component {
     const search = type !== 'search' ? null : {
       condition,
       pattern: pattern['item.data'].pattern,
-      type: pattern['item.data'].type
+      type: pattern['item.data'].type,
     };
 
     return (
@@ -395,9 +395,9 @@ export class DetailsCriteriaLine extends React.Component {
           { search ? (
             <>
               Condition: <strong>{search.condition}</strong>
-              <br/>
+              <br />
               Pattern: <strong>{search.pattern}</strong>
-              <br/>
+              <br />
               Type: <strong>{search.type}</strong>
             </>
           ) : pattern }


### PR DESCRIPTION
Resolves: [492](https://github.com/StackStorm/st2web/issues/492)

Adds support for Search Criteria and nested parameter fields for rules.

This recording demonstrates the current application without the "search" option in the UI. Since search functionality is implemented in the back-end but not the front-end, navigating to a rule that uses search crashes the application.

https://user-images.githubusercontent.com/46300738/162856765-e75741b7-d062-4287-a315-042542fdb7d5.mov



This next recording demonstrates the changes: Added search criteria input fields, as well as not crashing the app when selecting a rule using search:

https://user-images.githubusercontent.com/46300738/162855561-76fe2216-f97f-4af3-a95a-f21bdea9db07.mov


