### PR TITLE
Auto-Save Changes in the Workflow Composer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ Added
 
   Contributed by @Jappzy and @cded from @Bitovi
 
+* Added an optional auto-save capability in the workflow composer. #965, #993
+
+  Contributed by @Jappzy and @cded from @Bitovi
+
 Changed
 ~~~~~~~
 * Updated nodejs from `14.16.1` to `14.20.1`, fixing the local build under ARM processor architecture. #880

--- a/apps/st2-workflows/store.js
+++ b/apps/st2-workflows/store.js
@@ -273,6 +273,18 @@ const flowReducer = (state = {}, input) => {
       };
     }
 
+    case 'PUSH_WARNING': {
+      const { message, link, source } = input;
+
+      return {
+        ...state,
+        notifications: [
+          ...notifications.filter(n => !source || n.source !== source),
+          { type: 'warning', message, source, link, id: uniqueId() },
+        ],
+      };
+    }
+
     case 'PUSH_SUCCESS': {
       const { message, link, source } = input;
 

--- a/apps/st2-workflows/store.js
+++ b/apps/st2-workflows/store.js
@@ -403,6 +403,15 @@ const flowReducer = (state = {}, input) => {
       };
     }
 
+    case 'TOGGLE_AUTOSAVE': {
+      const { autosaveEnabled } = input;
+
+      return {
+        ...state,
+        autosaveEnabled,
+      };
+    }
+
     default:
       return state;
   }

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -307,7 +307,7 @@ export default class Workflows extends Component {
       if (autosaveEnabled) {
         this.save();
       }
-    }, 3000);
+    }, 1000);
   }
 
   style = style

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -302,8 +302,12 @@ export default class Workflows extends Component {
     func.apply(this);
     clearTimeout(this.timer);
     this.timer = setTimeout(() => {
-      this.save();
-    }, 2500);
+      const { autosaveEnabled } = store.getState();
+
+      if (autosaveEnabled) {
+        this.save();
+      }
+    }, 3000);
   }
 
   style = style

--- a/apps/st2-workflows/workflows.component.js
+++ b/apps/st2-workflows/workflows.component.js
@@ -290,7 +290,7 @@ export default class Workflows extends Component {
 
   autosave(func) {
     func.apply(this);
-    clearTimeout(timer);
+    clearTimeout(this.timer);
     this.timer = setTimeout(() => {
       this.save();
     }, 2500);

--- a/modules/st2flow-canvas/index.js
+++ b/modules/st2flow-canvas/index.js
@@ -383,7 +383,7 @@ export default class Canvas extends Component {
       // finally, place the unplaced tasks.  using handleTaskMove will also ensure
       //   that the placement gets set on the model and the YAML.
       needsCoords.forEach(({task, transitionsTo}) => {
-        this.handleTaskMove(task, sampler.getNext(task.name, transitionsTo),true);
+        this.handleTaskMove(task, sampler.getNext(task.name, transitionsTo), true);
       });
     }
   }
@@ -572,15 +572,15 @@ export default class Canvas extends Component {
     return false;
   }
 
-  handleTaskMove = async (task: TaskRefInterface, points: CanvasPoint,autoSave) => {
+  handleTaskMove = async (task: TaskRefInterface, points: CanvasPoint, autoSave = true) => {
     const x = points.x;
     const y = points.y;
     const coords = {x, y};
     this.props.issueModelCommand('updateTask', task, { coords });
     
-    if(autoSave && !this.props.dirtyflag) {
-      await this.props.fetchActionscalled();
+    if (autoSave && this.props.dirtyflag) {
       this.props.saveData();
+      await this.props.fetchActionscalled();
     }  
    
   }
@@ -603,16 +603,25 @@ export default class Canvas extends Component {
     this.props.navigate({ toTasks: undefined, task: task.name });
   }
 
-  handleTaskDelete = (task: TaskRefInterface) => {
+  handleTaskDelete = (task: TaskRefInterface, autosave = true) => {
     this.props.issueModelCommand('deleteTask', task);
+    if (autosave) {
+      this.props.saveData();
+    }
   }
 
-  handleTaskConnect = (to: TaskRefInterface, from: TaskRefInterface) => {
+  handleTaskConnect = (to: TaskRefInterface, from: TaskRefInterface, autosave = true) => {
     this.props.issueModelCommand('addTransition', { from, to: [ to ] });
+    if (autosave) {
+      this.props.saveData();
+    }
   }
 
-  handleTransitionDelete = (transition: TransitionInterface) => {
+  handleTransitionDelete = (transition: TransitionInterface, autosave = true) => {
     this.props.issueModelCommand('deleteTransition', transition);
+    if (autosave) {
+      this.props.saveData();
+    }
   }
 
   get notifications() : Array<NotificationInterface> {
@@ -749,7 +758,7 @@ export default class Canvas extends Component {
                       task={task}
                       selected={task.name === navigation.task && !selectedTransitionGroups.length}
                       scale={scale}
-                      onMove={(...a) => this.handleTaskMove(task, ...a,false)}
+                      onMove={(...a) => this.handleTaskMove(task, ...a, true)}
                       onConnect={(...a) => this.handleTaskConnect(task, ...a)}
                       onClick={() => this.handleTaskSelect(task)}
                       onDelete={() => this.handleTaskDelete(task)}

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -141,7 +141,7 @@ export default class Details extends Component<{
               );
             })
           }
-          <input id='autosave-checkbox' name='autosave-checkbox' type='checkbox' onChange={(e) => this.toggleAutosave(e.target.checked)} className={cx(style.autosave)} />
+          <input id='autosave-checkbox' name='autosave-checkbox' type='checkbox' onChange={(e) => { this.toggleAutosave(e.target.checked); onChange();}} className={cx(style.autosave)} />
           <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
           <ToolbarButton className={cx(style.code, 'icon-code')} selected={asCode} onClick={() => navigate({ asCode: !asCode })} />
         </Toolbar>

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -112,7 +112,7 @@ export default class Details extends Component<{
   }
 
   render() {
-    const { actions, navigation, navigate } = this.props;
+    const { actions, navigation, navigate, onChange } = this.props;
 
     const { type = 'metadata', asCode } = navigation;
 
@@ -138,7 +138,7 @@ export default class Details extends Component<{
             asCode
               && <MetaEditor />
               // $FlowFixMe Model is populated via decorator
-              || <Meta />
+              || <Meta onChange={() => onChange()} />
           )
         }
         {

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -126,6 +126,8 @@ export default class Details extends Component<{
 
     const { type = 'metadata', asCode } = navigation;
 
+    const { autosaveEnabled } = store.getState();
+
     return (
       <div className={cx(this.props.className, this.style.component, asCode && 'code')}>
         <Toolbar>
@@ -147,12 +149,13 @@ export default class Details extends Component<{
             <input
               id='autosave-checkbox' 
               name='autosave-checkbox' 
-              type='checkbox' 
+              type='checkbox'
               onChange={(e) => {
                 this.toggleAutosave(e.target.checked);
                 onChange();
               }} 
               className={cx(style.autosave)}
+              defaultChecked={autosaveEnabled}
             />
             <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
           </div>

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -145,7 +145,7 @@ export default class Details extends Component<{
             id='autosave-checkbox' 
             name='autosave-checkbox' 
             type='checkbox' 
-            onChange={ (e) => { 
+            onChange={(e) => {
               this.toggleAutosave(e.target.checked);
               onChange();
             }} 

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -91,6 +91,8 @@ export default class Details extends Component<{
     navigate: PropTypes.func,
 
     actions: PropTypes.array,
+
+    onChange: PropTypes.func,
   }
 
   sections = [{

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -141,17 +141,21 @@ export default class Details extends Component<{
               );
             })
           }
-          <input 
-            id='autosave-checkbox' 
-            name='autosave-checkbox' 
-            type='checkbox' 
-            onChange={(e) => {
-              this.toggleAutosave(e.target.checked);
-              onChange();
-            }} 
-            className={cx(style.autosave)}
-          />
-          <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
+          <div
+            style={{display: 'flex'}} title="Automatically save the workflow on every change"
+          >
+            <input
+              id='autosave-checkbox' 
+              name='autosave-checkbox' 
+              type='checkbox' 
+              onChange={(e) => {
+                this.toggleAutosave(e.target.checked);
+                onChange();
+              }} 
+              className={cx(style.autosave)}
+            />
+            <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
+          </div>
           <ToolbarButton className={cx(style.code, 'icon-code')} selected={asCode} onClick={() => navigate({ asCode: !asCode })} />
         </Toolbar>
         {

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -141,14 +141,23 @@ export default class Details extends Component<{
               );
             })
           }
-          <input id='autosave-checkbox' name='autosave-checkbox' type='checkbox' onChange={(e) => { this.toggleAutosave(e.target.checked); onChange();}} className={cx(style.autosave)} />
+          <input 
+            id='autosave-checkbox' 
+            name='autosave-checkbox' 
+            type='checkbox' 
+            onChange={ (e) => { 
+              this.toggleAutosave(e.target.checked);
+              onChange();
+            }} 
+            className={cx(style.autosave)}
+          />
           <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
           <ToolbarButton className={cx(style.code, 'icon-code')} selected={asCode} onClick={() => navigate({ asCode: !asCode })} />
         </Toolbar>
         {
           type === 'metadata' && (
             asCode
-              && <MetaEditor />
+              && <MetaEditor onChange={() => onChange()} />
               // $FlowFixMe Model is populated via decorator
               || <Meta onChange={() => onChange()} />
           )
@@ -156,7 +165,7 @@ export default class Details extends Component<{
         {
           type === 'execution' && (
             asCode
-              && <WorkflowEditor selectedTaskName={navigation.task} onTaskSelect={this.handleTaskSelect} />
+              && <WorkflowEditor selectedTaskName={navigation.task} onTaskSelect={this.handleTaskSelect} onChange={() => onChange()} />
               || navigation.task
                 // $FlowFixMe ^^
                 && <TaskDetails onBack={this.handleBack} selected={navigation.task} actions={actions} />

--- a/modules/st2flow-details/index.js
+++ b/modules/st2flow-details/index.js
@@ -32,6 +32,7 @@ import TaskDetails from './task-details';
 import TaskList from './task-list';
 
 import style from './style.css';
+import store from '../../apps/st2-workflows/store';
 
 @connect(
   editorConnect
@@ -113,6 +114,13 @@ export default class Details extends Component<{
     this.props.navigate({ toTasks: undefined, task: undefined });
   }
 
+  toggleAutosave = (autosaveEnabled) => {
+    store.dispatch({
+      type: 'TOGGLE_AUTOSAVE',
+      autosaveEnabled,
+    });
+  }
+
   render() {
     const { actions, navigation, navigate, onChange } = this.props;
 
@@ -133,6 +141,8 @@ export default class Details extends Component<{
               );
             })
           }
+          <input id='autosave-checkbox' name='autosave-checkbox' type='checkbox' onChange={(e) => this.toggleAutosave(e.target.checked)} className={cx(style.autosave)} />
+          <label id='autosave-checkbox__label' htmlFor='autosave-checkbox' className={cx(style.autosave)}>Autosave</label>
           <ToolbarButton className={cx(style.code, 'icon-code')} selected={asCode} onClick={() => navigate({ asCode: !asCode })} />
         </Toolbar>
         {

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -195,12 +195,54 @@ export default class Meta extends Component {
       </Toolbar>,
       section === 'meta' && (
         <Panel key="meta">
-          <EnumField name="Runner Type" value={meta.runner_type} spec={{enum: [ ...new Set([ 'mistral-v2', 'orquesta' ]) ], default: default_runner_type}} onChange={(v) => { setMeta('runner_type', v); onChange(); }} />
-          <EnumField name="Pack" value={pack} spec={{enum: packs}} onChange={(v) => { setPack(v); onChange(); }} />
-          <StringField name="Name" value={meta.name} onChange={(v) => this.setMetaNew('name', v || '')} />
-          <StringField name="Description" value={meta.description} onChange={(v) => { setMeta('description', v); onChange(); }} />
-          <BooleanField name="Enabled" value={meta.enabled} spec={{}} onChange={(v) => { setMeta('enabled', v); onChange(); }} />
-          <StringField name="Entry point" value={meta.entry_point !=='undefined' ? meta.entry_point:`workflows/${meta.name}.yaml`}  onChange={(v) => { setMeta('entry_point', v || ''); onChange(); }} />
+          <EnumField
+            name="Runner Type"
+            value={meta.runner_type}
+            spec={{enum: [ ...new Set([ 'mistral-v2', 'orquesta' ]) ], default: default_runner_type}}
+            onChange={(v) => {
+              setMeta('runner_type', v);
+              onChange();
+            }}
+          />
+          <EnumField
+            name="Pack"
+            value={pack}
+            spec={{enum: packs}}
+            onChange={(v) => {
+              setPack(v);
+              onChange();
+            }}
+          />
+          <StringField
+            name="Name"
+            value={meta.name}
+            onChange={(v) => this.setMetaNew('name', v || '')}
+          />
+          <StringField
+            name="Description"
+            value={meta.description}
+            onChange={(v) => {
+              setMeta('description', v);
+              onChange();
+            }}
+          />
+          <BooleanField
+            name="Enabled"
+            value={meta.enabled}
+            spec={{}}
+            onChange={(v) => {
+              setMeta('enabled', v);
+              onChange();
+            }}
+          />
+          <StringField
+            name="Entry point"
+            value={meta.entry_point !=='undefined' ? meta.entry_point:`workflows/${meta.name}.yaml`}
+            onChange={(v) => {
+              setMeta('entry_point', v || '');
+              onChange();
+            }}
+          />
         </Panel>
       ),
       section === 'parameters' && (

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -183,7 +183,7 @@ export default class Meta extends Component {
   }
 
   render() {
-    const { pack, setPack, meta, setMeta, navigation, actions, vars, onChange } = this.props;
+    const { pack, setPack, meta, setMeta, navigation, actions, vars } = this.props;
     const { section = 'meta' } = navigation;
     const stringVars = vars && vars.map(kv => {
       const key = Object.keys(kv)[0];

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -100,11 +100,25 @@ export default class Meta extends Component {
     onChange: PropTypes.func,
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const { meta, setMeta } = this.props;
 
     if (!meta.runner_type) {
       setMeta('runner_type', default_runner_type);
+    }
+
+    this.handleAutoSaveUpdates(prevProps);
+  }
+
+  handleAutoSaveUpdates(prevProps) {
+    const { meta, vars, onChange } = this.props;
+
+    if(prevProps.meta !== meta) {
+      onChange();
+    }
+
+    if(prevProps.vars !== vars) {
+      onChange();
     }
   }
 
@@ -113,7 +127,7 @@ export default class Meta extends Component {
   }
 
   handleVarsChange(publish: Array<{}>) {
-    const { setVars, onChange } = this.props;
+    const { setVars } = this.props;
     const val = (publish ? publish.slice(0) : []).map(kv => {
       const key = Object.keys(kv)[0];
       const val = kv[key];
@@ -136,7 +150,6 @@ export default class Meta extends Component {
 
     // Make sure to mutate the copy
     setVars(val);
-    onChange();
   }
 
   addVar() {
@@ -159,7 +172,6 @@ export default class Meta extends Component {
         command: 'set',
         args: [ 'entry_point',entryPoint ],
       });
-      this.props.onChange();
     }
     catch(error) {
       store.dispatch({
@@ -199,19 +211,13 @@ export default class Meta extends Component {
             name="Runner Type"
             value={meta.runner_type}
             spec={{enum: [ ...new Set([ 'mistral-v2', 'orquesta' ]) ], default: default_runner_type}}
-            onChange={(v) => {
-              setMeta('runner_type', v);
-              onChange();
-            }}
+            onChange={(v) => setMeta('runner_type', v)}
           />
           <EnumField
             name="Pack"
             value={pack}
             spec={{enum: packs}}
-            onChange={(v) => {
-              setPack(v);
-              onChange();
-            }}
+            onChange={(v) => setPack(v)}
           />
           <StringField
             name="Name"
@@ -221,27 +227,18 @@ export default class Meta extends Component {
           <StringField
             name="Description"
             value={meta.description}
-            onChange={(v) => {
-              setMeta('description', v);
-              onChange();
-            }}
+            onChange={(v) => setMeta('description', v)}
           />
           <BooleanField
             name="Enabled"
             value={meta.enabled}
             spec={{}}
-            onChange={(v) => {
-              setMeta('enabled', v);
-              onChange();
-            }}
+            onChange={(v) => setMeta('enabled', v)}
           />
           <StringField
             name="Entry point"
             value={meta.entry_point !=='undefined' ? meta.entry_point:`workflows/${meta.name}.yaml`}
-            onChange={(v) => {
-              setMeta('entry_point', v || '');
-              onChange();
-            }}
+            onChange={(v) => setMeta('entry_point', v || '')}
           />
         </Panel>
       ),

--- a/modules/st2flow-details/meta-panel.js
+++ b/modules/st2flow-details/meta-panel.js
@@ -96,6 +96,8 @@ export default class Meta extends Component {
     actions: PropTypes.array,
     vars: PropTypes.array,
     setVars: PropTypes.func,
+
+    onChange: PropTypes.func,
   }
 
   componentDidUpdate() {
@@ -111,7 +113,7 @@ export default class Meta extends Component {
   }
 
   handleVarsChange(publish: Array<{}>) {
-    const { setVars } = this.props;
+    const { setVars, onChange } = this.props;
     const val = (publish ? publish.slice(0) : []).map(kv => {
       const key = Object.keys(kv)[0];
       const val = kv[key];
@@ -134,6 +136,7 @@ export default class Meta extends Component {
 
     // Make sure to mutate the copy
     setVars(val);
+    onChange();
   }
 
   addVar() {
@@ -156,6 +159,7 @@ export default class Meta extends Component {
         command: 'set',
         args: [ 'entry_point',entryPoint ],
       });
+      this.props.onChange();
     }
     catch(error) {
       store.dispatch({
@@ -167,7 +171,7 @@ export default class Meta extends Component {
   }
 
   render() {
-    const { pack, setPack, meta, setMeta, navigation, actions, vars } = this.props;
+    const { pack, setPack, meta, setMeta, navigation, actions, vars, onChange } = this.props;
     const { section = 'meta' } = navigation;
     const stringVars = vars && vars.map(kv => {
       const key = Object.keys(kv)[0];
@@ -191,12 +195,12 @@ export default class Meta extends Component {
       </Toolbar>,
       section === 'meta' && (
         <Panel key="meta">
-          <EnumField name="Runner Type" value={meta.runner_type} spec={{enum: [ ...new Set([ 'mistral-v2', 'orquesta' ]) ], default: default_runner_type}} onChange={(v) => setMeta('runner_type', v)} />
-          <EnumField name="Pack" value={pack} spec={{enum: packs}} onChange={(v) => setPack(v)} />
+          <EnumField name="Runner Type" value={meta.runner_type} spec={{enum: [ ...new Set([ 'mistral-v2', 'orquesta' ]) ], default: default_runner_type}} onChange={(v) => { setMeta('runner_type', v); onChange(); }} />
+          <EnumField name="Pack" value={pack} spec={{enum: packs}} onChange={(v) => { setPack(v); onChange(); }} />
           <StringField name="Name" value={meta.name} onChange={(v) => this.setMetaNew('name', v || '')} />
-          <StringField name="Description" value={meta.description} onChange={(v) => setMeta('description', v)} />
-          <BooleanField name="Enabled" value={meta.enabled} spec={{}} onChange={(v) => setMeta('enabled', v)} />
-          <StringField name="Entry point" value={meta.entry_point !=='undefined' ? meta.entry_point:`workflows/${meta.name}.yaml`}  onChange={(v) => setMeta('entry_point', v || '')} />
+          <StringField name="Description" value={meta.description} onChange={(v) => { setMeta('description', v); onChange(); }} />
+          <BooleanField name="Enabled" value={meta.enabled} spec={{}} onChange={(v) => { setMeta('enabled', v); onChange(); }} />
+          <StringField name="Entry point" value={meta.entry_point !=='undefined' ? meta.entry_point:`workflows/${meta.name}.yaml`}  onChange={(v) => { setMeta('entry_point', v || ''); onChange(); }} />
         </Panel>
       ),
       section === 'parameters' && (

--- a/modules/st2flow-details/style.css
+++ b/modules/st2flow-details/style.css
@@ -397,3 +397,8 @@ limitations under the License.
 .tooltip {
   position: relative;
 }
+
+.autosave {
+  cursor: pointer;
+  margin-left: 4px;
+}

--- a/modules/st2flow-editor/index.js
+++ b/modules/st2flow-editor/index.js
@@ -56,6 +56,7 @@ export default class Editor extends Component<{
     onTaskSelect: PropTypes.func,
     source: PropTypes.string,
     onEditorChange: PropTypes.func,
+    onChange: PropTypes.func,
   }
 
   componentDidMount() {
@@ -142,6 +143,7 @@ export default class Editor extends Component<{
   }
 
   handleEditorChange = (delta: DeltaInterface) => {
+    const { onChange } = this.props;
     window.clearTimeout(this.deltaTimer);
 
     // Only if the user is actually typing
@@ -149,6 +151,7 @@ export default class Editor extends Component<{
       this.deltaTimer = window.setTimeout(() => {
         if (this.props.onEditorChange) {
           this.props.onEditorChange(this.editor.getValue());
+          onChange();
         }
       }, DELTA_DEBOUNCE);
     }


### PR DESCRIPTION
Closes #993

Adds a checkbox in the Workflow Composer to toggle "Auto-Save". When enabled, all changes in the Workflow Composer are debounced by 3 seconds and then automatically saved. This is an added enhancement to the save button and keyboard shortcut.


https://user-images.githubusercontent.com/46300738/163027284-9fb884ea-345d-4e80-9ebb-62a07d746c81.mov
