### PR TITLE
Disable web buttons in forms after onClick

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,4 +3,11 @@ Changelog
 
 in development
 --------------
-* Create a changelog and required machinery
+
+Added
+~~~~~
+
+* Added feature for disabling button for synchronous responses
+    - Button gets disabled onClick on `Connect` and `Submit` in st2-login and st2-history module respectively
+
+    Contributed by @ParthS007

--- a/apps/st2-history/history-popup.component.js
+++ b/apps/st2-history/history-popup.component.js
@@ -39,6 +39,7 @@ export default class HistoryPopup extends React.Component {
 
   state = {
     preview: false,
+    disabled: false,
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -89,6 +90,7 @@ export default class HistoryPopup extends React.Component {
       delete this.state.payload[payLoadKey];
     }
     this.props.onSubmit(this.state.payload);
+    this.setState({ disabled: true });
   }
 
   render() {
@@ -136,6 +138,7 @@ export default class HistoryPopup extends React.Component {
                     submit
                     className="st2-details__toolbar-button"
                     value="Submit"
+                    disabled={this.state.disabled}
                     onClick={(e) => this.handleSubmit(e)}
                     data-test="rerun_submit"
                   />

--- a/modules/st2-login/login.component.js
+++ b/modules/st2-login/login.component.js
@@ -157,6 +157,7 @@ export default class Login extends React.Component {
       username: '',
       password: '',
       remember: true,
+      disabled: false,
   
       server,
       servers,
@@ -168,13 +169,13 @@ export default class Login extends React.Component {
 
   connect(e) {
     e.preventDefault();
-
+    this.setState({ disabled: true });
     this.setState({ error: null });
 
     const { server, username, password, remember } = this.state;
     return api.connect(server, username, password, remember)
       .then(() => this.props.onConnect())
-      .catch((err) => this.setState({ error: err.message }))
+      .catch((err) => this.setState({ error: err.message, disabled: false }))
     ;
   }
 
@@ -240,6 +241,7 @@ export default class Login extends React.Component {
               className={cx('st2-forms__button', style.button)}
               type="submit"
               value="Connect"
+              disabled={this.state.disabled}
             />
 
             <label className={style.checkboxWrapper}>


### PR DESCRIPTION
ref #975 

- Add disable functionality on Submit the rerun and Login component
- Now the user will not be able to send multiple request to `Connect(Login)` before receiving the response from server by adding the `disabled` in `input`.


- **Before Rerun**

https://user-images.githubusercontent.com/24358501/166924395-49c0a26c-9664-474c-b737-aeb8774bb701.mov

- **After Rerun**

https://user-images.githubusercontent.com/24358501/166924488-f97dd517-ea4c-458f-b674-48682402da91.mov


