### PR TITLE
Fix circleci node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,9 @@ jobs:
             node -v
       - run:
           name: Check node version at start
-          command: node -v
+          command: |
+            node -v
+            nvm ls
       - run:
           name: Export package version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,13 @@ jobs:
       - run:
           name: Install package dependencies
           command: |
-            nvm use 14.6.1
+            nvm use 14.16.1
             lerna bootstrap
 
       - run:
           name: Run unit tests
           command: |
-            nvm use 14.6.1
+            nvm use 14.16.1
             npm run test-unit
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
           command: |
             node -v
             nvm ls
+            nvm use 14.16.1
+            node -v
       - run:
           name: Export package version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,18 @@ jobs:
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:
+          name: Check node version
+          command: node -v
+      - run:
           name: Install system dependencies
           command: |
             sudo apt-get update
             sudo apt-get install rpm jq devscripts debhelper
             gem install package_cloud
             npm install --global lerna yarn
+      - run:
+          name: Check node version after install of system dependencies
+          command: node -v
       - run:
           name: Install package dependencies
           command: lerna bootstrap
@@ -78,7 +84,7 @@ jobs:
             echo "Cloning ${ST2_DOCKER_BRANCH:-master} branch of st2-docker"
             git clone --branch ${ST2_DOCKER_BRANCH:-master} --depth 1 ${ST2_TEST_ENVIRONMENT} ~/st2-docker
       - run:
-          name: Configufe docker compose config
+          name: Configure docker compose config
           command: |
             # Configure allow origin in the user config
             echo "[api]" > ~/st2-docker/files/st2.user.conf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
             nvm install 14.16.1
             nvm alias default 14.16.1
+            nvm use 14.16.1
 
             # Each step uses the same `$BASH_ENV`, so need to modify it
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
@@ -60,7 +61,7 @@ jobs:
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:
-          name: Check node version
+          name: Change node version
           command: node -v
       - run:
           name: Install system dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,21 +35,10 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
             nvm install 14.16.1
             nvm alias default v14.16.1
-            nvm use 14.16.1
 
             # Each step uses the same `$BASH_ENV`, so need to modify it
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
             echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-
-            # Check node version
-            node -v
-      - run:
-          name: Check node version at start
-          command: |
-            node -v
-            nvm ls
-            nvm use 14.16.1
-            node -v
       - run:
           name: Export package version
           command: |
@@ -63,9 +52,6 @@ jobs:
             echo "export PKG_VERSION=${PKG_VERSION}" >> $BASH_ENV
             echo "export PKG_RELEASE=${PKG_RELEASE}" >> $BASH_ENV
       - run:
-          name: Change node version
-          command: node -v
-      - run:
           name: Install system dependencies
           command: |
             sudo apt-get update
@@ -73,15 +59,16 @@ jobs:
             gem install package_cloud
             npm install --global lerna yarn
       - run:
-          name: Check node version after install of system dependencies
-          command: node -v
-      - run:
           name: Install package dependencies
-          command: lerna bootstrap
+          command: |
+            nvm use 14.6.1
+            lerna bootstrap
 
       - run:
           name: Run unit tests
-          command: npm run test-unit
+          command: |
+            nvm use 14.6.1
+            npm run test-unit
 
       - run:
           name: Update Docker Compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install rpm jq devscripts debhelper
             gem install package_cloud
+            nvm use 14.16.1
             npm install --global lerna yarn
       - run:
           name: Install package dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
             nvm install 14.16.1
-            nvm alias default 14.16.1
+            nvm alias default v14.16.1
             nvm use 14.16.1
 
             # Each step uses the same `$BASH_ENV`, so need to modify it

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
             # Each step uses the same `$BASH_ENV`, so need to modify it
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
             echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+
+            # Check node version
+            node -v
+      - run:
+          name: Check node version at start
+          command: node -v
       - run:
           name: Export package version
           command: |


### PR DESCRIPTION
The node version is not being kept between runs, and therefore was defaulting back to node 16.

This has been reported before, see https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813. But setting alias to v<version> didn't help.

Resolved problem by adding nvm use to each step, as at moment none of our st2web builds work. 