### PR TITLE
Update Node version to current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
             set +e
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-            nvm install 14.20.1
-            nvm alias default v14.20.1
+            nvm install 20.8.1
+            nvm alias default v20.8.1
 
             # Each step uses the same `$BASH_ENV`, so need to modify it
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
@@ -59,18 +59,18 @@ jobs:
             sudo apt-get update
             sudo apt-get install rpm jq devscripts debhelper
             gem install package_cloud
-            nvm use 14.20.1
+            nvm use 20.8.1
             npm install --global lerna@6.0.0 yarn
       - run:
           name: Install package dependencies
           command: |
-            nvm use 14.20.1
+            nvm use 20.8.1
             lerna bootstrap
 
       - run:
           name: Run unit tests
           command: |
-            nvm use 14.20.1
+            nvm use 20.8.1
             npm run test-unit
 
       - run:
@@ -129,13 +129,13 @@ jobs:
       - run:
           name: Make deb packages
           command: |
-            nvm use 14.20.1
+            nvm use 20.8.1
             make deb
             echo $DEB | tr ' ' '\n' | xargs -I{} cp -vr ../st2web_*.{deb,changes} ~/artifacts/{}
       - run:
           name: Make RPM packages
           command: |
-            nvm use 14.20.1
+            nvm use 20.8.1
             make rpm
             echo $RPM | tr ' ' '\n' | xargs -I{} cp -vr ../st2web-*.rpm ~/artifacts/{}
       - store_artifacts:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changed
 
   Contributed by @enykeev
 
+* Updated NodeJS to v20 current (security). #1010
+
+  Contributed by @enykeev
+
 Fixed
 ~~~~~
 * Fixed CircleCI tests by pinning lerna@6.0.0. #1008

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.20.1
+FROM node:20.8.1
 
 # Create app directory
 WORKDIR /opt/stackstorm/static/webui/st2web

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM node:14.20.1
+FROM node:20.8.1
 
 # Create app directory
 WORKDIR /opt/stackstorm/static/webui/st2web

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,4 +1,4 @@
-FROM node:14.20.1 as build
+FROM node:20.8.1 as build
 
 # Create app directory
 WORKDIR /opt/stackstorm/static/webui/st2web

--- a/Dockerfile-nginx-dev
+++ b/Dockerfile-nginx-dev
@@ -1,4 +1,4 @@
-FROM node:14.20.1 as build
+FROM node:20.8.1 as build
 
 # Create app directory
 WORKDIR /opt/stackstorm/static/webui/st2web

--- a/README.md
+++ b/README.md
@@ -12,19 +12,18 @@ Quick start
 First of all, you need to make sure you have `node` and `npm` packages installed. Currently, we consider Node v14.x.x to be our stable.
 
 ```shell
-$ n 14
-
-install : node-v14.17.0
-  mkdir : /usr/local/n/versions/node/14.17.0
-  fetch : https://nodejs.org/dist/v14.17.0/node-v14.17.0-darwin-x64.tar.gz
-######################################################################## 100.0%
-installed : v14.17.0
+$ n 20
+  installing : node-v20.8.1
+       mkdir : /home/enykeev/n/n/versions/node/20.8.1
+       fetch : https://nodejs.org/dist/v20.8.1/node-v20.8.1-linux-x64.tar.xz
+     copying : node/20.8.1
+   installed : v20.8.1 (with npm 10.1.0)
 
 $ node -v
-v14.17.0
+v20.8.1
 
 $ npm -v
-6.14.13
+10.1.0
 ```
 
 then you need to globally install `gulp`, `lerna` and `yarn`

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "repository": "stackstorm/st2web",
   "engines": {
-    "node": "14.20.1",
-    "npm": "6.14.12"
+    "node": "20.8.1",
+    "npm": "10.1.0"
   },
   "browserify": {
     "transform": [
@@ -79,7 +79,7 @@
     "minimatch": "^3.0.4",
     "mixin-deep": "^1.3.2",
     "moment": "2.24.0",
-    "node": "14.20.1",
+    "node": "20.8.1",
     "node-uuid": "^1.4.8",
     "open": "^8.4.0",
     "qs": "^6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8798,10 +8798,10 @@ node.extend@^1.0.10:
     has "^1.0.3"
     is "^3.2.1"
 
-node@14.20.1:
-  version "14.20.1"
-  resolved "https://registry.yarnpkg.com/node/-/node-14.20.1.tgz#09e5d4a06d48fdcbeca1ec1ae10bbe02901d36b9"
-  integrity sha512-X+ds8FIkd5O+o6uuZKjP8ONH64PN8B+bsR2atkyx5anwruCPRyqHQRFQzG80Ymxv/lptRm3emXvvVpiMLl2qLg==
+node@20.8.1:
+  version "20.8.1"
+  resolved "https://registry.yarnpkg.com/node/-/node-20.8.1.tgz#fc2da9cbe07986a67c753072b258d139de1e4d0f"
+  integrity sha512-gG+nhijBgjTNjgPB4BxKaBKnFS49bngOuxw1/jVh4vlscg/6K+00n+2Q4LEnklTZJXFUQM+AqyGdfvh9h1JknA==
   dependencies:
     node-bin-setup "^1.0.0"
 


### PR DESCRIPTION
This PR updates Node version being used during build and test runs. The web app itself does not have any dependencies on libraries provided by Node, but it's still good to keep this dependency reasonably up to date.

Node v20 is about to become LTS in the next few days. Seems like a good timing to ensure we're compatible with the current version.